### PR TITLE
login host enhancements

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -15,7 +15,13 @@ login controller
             remember: localStorageService.get('remember') || false
         }
 
+        this.hosts = localStorageService.get('hosts') || [];
+
         this.host = $scope.host;
+        var params =  $location.search()
+
+        if(params.host)
+            this.host = params.host;
 
         // to be referenced in the signIn function
         var login = this;
@@ -33,6 +39,11 @@ login controller
                 $scope.eula = data.eula
                 $cookies.put('host', login.host)
                 $scope.$emit('host', host)
+                var hosts = localStorageService.get('hosts') || []
+                if(hosts.indexOf(host) < 0) {
+                    login.hosts = hosts.concat(host)
+                    localStorageService.add('hosts', login.hosts)
+                }
 
                 var token = $cookies.get('DrAuthToken')
                 if (typeof token !== 'undefined') {

--- a/views/login.html
+++ b/views/login.html
@@ -70,12 +70,19 @@ login view
 					</md-button>
 					
 				</span>
-				<md-input-container class="md-block" flex>
-					<label>API Endpoint</label>
-					<input type="text"
-						ng-model='login.host'
-						ng-model-options="{ debounce: 500 }"/>
-				</md-input-container>
+        <md-autocomplete flex class="md-block" ng-init='search=login.host'
+            md-selected-item="selected"
+            md-search-text="search"
+            md-search-text-change="login.host=search;delayTest()"
+            md-items="item in login.hosts | filter:search"
+            md-selected-item-change="login.host=selected||search;delayTest()"
+            md-item-text="item"
+            ng-model-options="{ debounce: 500 }"
+            md-floating-label="API Endpoint">
+          <md-item-template>
+            <span md-highlight-text="search">{{item}}</span>
+          </md-item-template>
+        </md-autocomplete>
 
 				<md-button class='md-primary' ng-click='delayTest()'>
 					Retry


### PR DESCRIPTION
added memory and autocomplete to host input on login, allow host to be put in url (?host=https://1.2.3.4)

hosts are cached when the query to api/license is successful