### PR TITLE
Node role static top

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 
     <md-content layout="column" layout-fill class='bg'>
       <!-- Header -->
-      <md-toolbar layout="column" class='md-whiteframe-z1' ng-show='isAuth()'>
+      <md-toolbar layout="column" class='md-whiteframe-z1' ng-show='isAuth()' id='toolbar'>
         <div class='md-toolbar-tools'>
           <md-button class="md-icon-button" ng-click="toggleSideNav('left')" hide-gt-md aria-label="Menu" />
           <md-icon>menu</md-icon>
@@ -170,7 +170,7 @@
       </md-toolbar>
 
       <!-- Content -->
-      <div ng-view ng-cloak style='overflow: auto;'>
+      <div ng-view ng-cloak style='overflow: auto;' scroll-position='scroll'>
       </div>
     </md-content>
 

--- a/js/app.js
+++ b/js/app.js
@@ -284,6 +284,22 @@ var version = '0.1.3';
     }
   ]);
 
+  app.directive('scrollPosition', function($window) {
+  return {
+    scope: {
+      scroll: '=scrollPosition'
+    },
+    link: function(scope, element, attrs) {
+      var windowEl = angular.element($window);
+      var handler = function() {
+        scope.scroll = windowEl.scrollTop();
+      }
+      windowEl.on('scroll', scope.$apply.bind(scope, handler));
+      handler();
+    }
+  };
+});
+
   app.controller('AppCtrl', function ($scope, $location, localStorageService, $mdSidenav, api) {
     $scope.toggleSideNav = function (menuId) {
       $mdSidenav(menuId).toggle();

--- a/js/app.js
+++ b/js/app.js
@@ -290,11 +290,11 @@ var version = '0.1.3';
       scroll: '=scrollPosition'
     },
     link: function(scope, element, attrs) {
-      var windowEl = angular.element($window);
+      //var windowEl = angular.element($window);
       var handler = function() {
-        scope.scroll = windowEl.scrollTop();
+        scope.scroll = element.scrollTop();
       }
-      windowEl.on('scroll', scope.$apply.bind(scope, handler));
+      element.on('scroll', scope.$apply.bind(scope, handler));
       handler();
     }
   };
@@ -307,6 +307,7 @@ var version = '0.1.3';
 
     $scope.api = api;
     $scope.reload = api.reload;
+    $scope.scroll = 0;
 
     $scope.menu = [{
       title: 'Deployments',

--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -9,7 +9,23 @@ node role controller
     var node_roles = this;
 
     $scope.myOrder = 'id';
-    $scope.scroll = 0;
+
+    // used for showing the toolbar when scrolling beyond the runlog
+    $scope.style = {};
+    $scope.top = 0;
+    $scope.$watch('scroll', function(){
+      var top = $('#runlog').position().top - $('#runlog').height();
+      $scope.top = top;
+      if(top < 0) { // the top of the runlog toolbar is offscreen
+        $scope.style = {
+          position: 'fixed',
+          width: $('#runlog').width(),
+          top: $('#toolbar').height()
+        };
+      } else {
+        $scope.style = {};
+      }
+    })
 
     this.selected = [];
 

--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -8,7 +8,9 @@ node role controller
 
     var node_roles = this;
 
-    $scope.myOrder = 'id'
+    $scope.myOrder = 'id';
+    $scope.scroll = 0;
+
     this.selected = [];
 
     // converts the _node_roles object that rootScope has into an array

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -1,5 +1,5 @@
 <md-card>
-  <md-toolbar class="md-default" md-theme='status_{{node_role.status}}'>
+  <md-toolbar class="md-default" md-theme='status_{{node_role.status}}' ng-style="style">
     <div class="md-toolbar-tools">
       <span>
         <md-icon class='md-primary'>
@@ -33,6 +33,13 @@
     </div>
 
   </md-toolbar>
+
+  <md-toolbar ng-if='top < 0'>
+    <div class='md-toolbar-tools'>
+      <h2>Node Role</h2>
+    </div>
+  </md-toolbar>
+
   <div class="md-toolbar-tools">
     <span>Attributes</span>
   </div>
@@ -42,13 +49,13 @@
 </md-card>
 
 <!-- Run Log -->
-<md-card id='runlog'>
-  <md-toolbar class="md-table-toolbar md-default">
+<md-card>
+  <md-toolbar class="md-table-toolbar md-default" id='runlog'>
     <div class="md-toolbar-tools">
       <span>Run Log</span>
     </div>
   </md-toolbar>
   <md-card-content>
     <pre class='runlog'>{{node_role.runlog || "None"}}</pre>
-    <md-card-content>
+  <md-card-content>
 </md-card>

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -57,5 +57,5 @@
   </md-toolbar>
   <md-card-content>
     <pre class='runlog'>{{node_role.runlog || "None"}}</pre>
-  <md-card-content>
+  </md-card-content>
 </md-card>

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -42,7 +42,7 @@
 </md-card>
 
 <!-- Run Log -->
-<md-card>
+<md-card id='runlog'>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
       <span>Run Log</span>


### PR DESCRIPTION
when scrolling past the runlog, the node role toolbar will be fixed at the top of the screen