### PR TITLE
Don't poll when something isn't selected.  This causes

### DIFF
--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -168,7 +168,7 @@ node role controller
     }
 
     $scope.getApiUpdate = function () {
-      if ($scope.editing || !$scope.node_role) return;
+      if ($scope.editing || !$scope.node_role || !$scope.id) return;
 
       api.fetch('node_role', $scope.id).success(function () {
         $scope.updateInterval = $timeout($scope.getApiUpdate, 2000);


### PR DESCRIPTION
a poll for an undefined object.  The API returns the error correctly,
but we should not spam.