### PR TITLE
Allow users to edit attributes for node-roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" type="text/css" href="bower_components/angular-material-data-table/dist/md-data-table.min.css" />
 
     <link rel="stylesheet" type="text/css" href="css/style.css" />
+    <link rel="SHORTCUT ICON" href="/ux/favicon.ico" />
 
     <title>
       Digital Rebar [{{host}}]

--- a/js/app.js
+++ b/js/app.js
@@ -64,6 +64,11 @@ var version = '0.1.3';
       'default': '500'
     }).accentPalette('grey', { 'default': '900' });
 
+    $mdThemingProvider.theme('status_proposed').
+    primaryPalette('blue', {
+      'default': '400'
+    }).accentPalette('grey', { 'default': '900' });
+
     $mdThemingProvider.alwaysWatchTheme(true);
 
     $routeProvider.
@@ -617,7 +622,8 @@ var version = '0.1.3';
       'todo': 'play_circle_outline',
       'off': 'power_settings_new',
       'queue': 'update',
-      'reserved': 'pause_circle_outline'
+      'reserved': 'pause_circle_outline',
+      'proposed': 'add_circle_outline'
     };
 
     $rootScope.states = {
@@ -626,7 +632,7 @@ var version = '0.1.3';
       '1': 'todo', //todo
       '2': 'process', //transition
       '3': 'queue', //blocked
-      '4': 'reserved' //proposed
+      '4': 'proposed' //proposed
     };
 
 

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -383,14 +383,32 @@ dialog controller
       }
       var obj = { value: value };
       obj[target["obj"]] = target["id"];
-      api("/api/v2/attribs/" + id, {
-        method: 'PUT',
-        data: obj
+      // figure out right method to propose
+      var propose_url = '';
+      switch (target["obj"]) {
+        case "node_role_id":
+          propose_url = "/api/v2/node_roles/" + target["id"] + "/propose";
+          break;
+        case "deployment_role_id":
+          propose_url = "/api/v2/deployment_roles/" + target["id"] + "/propose";
+          break;
+      }
+      // put attrib in proposed mode
+      api(propose_url, { method: 'PUT'
       }).success(function (data) {
-        api.toast('Updated Attrib!');
-      }).
-      error(function (err) {
-        api.toast('Error updating attrib','attrib',err);
+        api("/api/v2/attribs/" + id, {
+          method: 'PUT',
+          data: obj
+        }).success(function (data) {
+          api.toast('Updated Attrib!');
+          // update the on screen value (no auto refresh on attribs)
+          locals.attrib.value = data.value;
+        }).
+        error(function (err) {
+          api.toast('Error updating attrib','attrib',err);
+        });
+      }).error(function (err) {
+        api.toast('Error proposing target object',target["obj"],err);
       });
       $mdDialog.hide();
     };

--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -59,6 +59,19 @@ node role controller
       }
     };
 
+    $scope.commit = function () {
+      // if we have a valid node selected
+      if ($scope.node_role.id) {
+        api('/api/v2/node_roles/' + $scope.node_role.id + '/commit', {
+          method: 'PUT'
+        }).success(api.addNodeRole)
+            .success($scope.updateScroll)
+            .error(function (err) {
+              api.toast('Error committing node role', 'node_role', err);
+            });
+      }
+    };
+
     $scope.destroySelected = function () {
       $scope.confirm(event, {
         title: "Destroy Node Roles",

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -22,7 +22,11 @@
         </a>
       </span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='retry()'>
+      <md-button class='md-icon-button' ng-click='commit()' ng-show='node_role.state == 4' >
+        <md-icon>save</md-icon>
+        <md-tooltip>Commit</md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-click='retry()' ng-show='node_role.state != 4' >
         <md-icon>redo</md-icon>
         <md-tooltip>Retry</md-tooltip>
       </md-button>


### PR DESCRIPTION
This pull correctly manages the node-role proposed workflow.  
If a user edits the attrib then the code will automatically put the node-role into a proposed state.
The user can then commit that node-role directly or do it from the deployment.

We also had to correct the status to include "proposed" status instead of reserved.  (it appears that reserved for nodes does NOT work at this time).

NOTE: minor change to fix Icon required updating the line-endings.  actual change is adding line 13.