### PR TITLE
node address should be a HTTPS link

### DIFF
--- a/views/nodes.html
+++ b/views/nodes.html
@@ -79,7 +79,9 @@
           </td>
 
           <td md-cell><a ng-href='#/nodes/{{node.id}}'>{{node.name}}</a></td>
-          <td md-cell>{{node.address}}</td>
+          <td md-cell>
+            <a target="_new" ng-href="https://{{node.address.slice(0,-3)}}">{{node.address}}</a>
+          </td>
           <td md-cell>{{node.description}}</td>
           <td md-cell><a ng-href='#/providers/{{node.provider_id}}'>{{_providers[node.provider_id].name}}</a></td>
           <td md-cell>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -123,7 +123,9 @@
       </tr>
       <tr>
         <td class='label'>Address</td>
-        <td>{{node.address}}</td>
+        <td>
+          <a target="_new" ng-href="https://{{node.address.slice(0,-3)}}">{{node.address}}</a>
+        </td>
       </tr>
       <tr>
         <td class='label'>Status</td>


### PR DESCRIPTION
This makes it easier to jump to the website (assuming HTTPS) of a node.  

I'm assuming it's better to make this easier even if most nodes will 404 the address.