### PR TITLE
Provide correct feedback for Deployment Role Editing

### DIFF
--- a/js/deployment_roles.js
+++ b/js/deployment_roles.js
@@ -25,7 +25,10 @@ deployment role controller
       if ($scope.deployment_role.id) {
         api('/api/v2/deployment_roles/' + $scope.deployment_role.id + '/propose', {
           method: 'PUT'
-        }).success(api.addDeploymentRole).error(function (err) {
+        }).success(function () {
+          $scope.deployment_role.proposed = true;
+          api.addDeploymentRole;
+        }).error(function (err) {
           api.toast('Error Proposing Deployment Role', 'deployment_role', err);
         });
       }
@@ -36,7 +39,10 @@ deployment role controller
       if ($scope.deployment_role.id) {
         api('/api/v2/deployment_roles/' + $scope.deployment_role.id + '/commit', {
           method: 'PUT'
-        }).success(api.addDeploymentRole).error(function (err) {
+        }).success(function () {
+          $scope.deployment_role.proposed = false;
+          api.addDeploymentRole;
+        }).error(function (err) {
           api.toast('Error Committing Deployment Role' , 'deployment_role', err);
         });
       }

--- a/js/deployments.js
+++ b/js/deployments.js
@@ -168,6 +168,23 @@ deployments controller
       });
     };
 
+    // creates a confirmation dialog before redeploying the deployment
+    $scope.redeployDeployment = function (event, id) {
+      $scope.confirm(event, {
+        title: "Redeploy All Nodes in Deployment",
+        message: "Are you sure you want to redeploy " + $scope._deployments[id].name + "?",
+        yesCallback: function () {
+          api("/api/v2/deployments/" + id + "/redeploy", { method: "PUT" }).
+          success(function () {
+            $scope.updateMatrix($scope._deployments[id]);
+          }).
+          error(function (err) {
+            api.toast("Error Redeploying Deployment", 'deployment', err);
+          })
+        }
+      });
+    };
+
     // creates a confirmation dialog before deleting the deployment
     $scope.deleteDeployment = function (event, id) {
       $scope.confirm(event, {

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -403,6 +403,10 @@ dialog controller
           api.toast('Updated Attrib!');
           // update the on screen value (no auto refresh on attribs)
           locals.attrib.value = data.value;
+          // track local DR proposed
+          if (target["obj"] == "deployment_role_id") {
+            $rootScope._deployment_roles[target["id"]].proposed = true;
+          }
         }).
         error(function (err) {
           api.toast('Error updating attrib','attrib',err);

--- a/js/nodes.js
+++ b/js/nodes.js
@@ -19,18 +19,6 @@ node controller
       return nodes;
     };
 
-    this.getStatus = function(node) {
-      if (node.alive) {
-        if (node.available) {
-          return node.status;
-        } else {
-          return 'reserved';
-        }
-      } else {
-        return 'off';
-      }
-    }
-
     this.deleteSelected = function (event) {
       $scope.confirm(event, {
         title: "Delete Nodes",

--- a/js/rebar.js
+++ b/js/rebar.js
@@ -636,6 +636,26 @@
       });
     };
 
+    api.getNodeStatus = function(node) {
+      if (node.alive) {
+        if (node.available) {
+          return node.status;
+        } else {
+          return 'reserved';
+        }
+      } else {
+        return 'off';
+      }
+    }
+
+    api.getNodeIcon = function(node) {
+      var ns = api.getNodeStatus(node);
+      if (ns === 'ready')
+        return node.icon;
+      else
+        return $rootScope.icons[ns];
+    }
+
     return api;
 
   });

--- a/views/deployment_roles_singular.html
+++ b/views/deployment_roles_singular.html
@@ -1,7 +1,10 @@
 <md-card>
-  <md-toolbar>
+  <md-toolbar class="md-default" md-theme='{{ deployment_role.proposed ? "status_proposed" : "status_ready" }}' ng-style="style">
     <div class="md-toolbar-tools">
       <span>
+        <md-icon class='md-primary'>
+          {{ icons[ deployment_role.proposed ? "proposed" : "ready"] }}
+        </md-icon>
         <a ng-href='#/deployments/{{deployment_role.deployment_id}}' swap-md-paint-fg="default foreground">
           {{_deployments[deployment_role.deployment_id].name}}
         </a>

--- a/views/deployment_roles_singular.html
+++ b/views/deployment_roles_singular.html
@@ -14,12 +14,12 @@
       </span>
       <span flex></span>
 
-      <md-button class='md-icon-button' ng-click='propose()'>
+      <md-button class='md-icon-button' ng-if='!deployment_role.proposed' ng-click='propose()'>
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Propose</md-tooltip>
       </md-button>
 
-      <md-button class='md-icon-button' ng-click='commit()'>
+      <md-button class='md-icon-button' ng-if='deployment_role.proposed' ng-click='commit()'>
         <md-icon>save</md-icon>
         <md-tooltip>Commit</md-tooltip>
       </md-button>

--- a/views/deployments.html
+++ b/views/deployments.html
@@ -46,13 +46,12 @@ deployments view
           <!-- Add all the nodes as list items -->
           <span ng-repeat="node in _nodes | from:'deployment':deployment | filter:{system: false} | orderBy: 'name'">
               <!-- Node button -->
-              <md-button class="md-fab md-primary md-mini" md-theme="status_{{node.status}}" ng-href="#/nodes/{{node.id}}">
+              <md-button class="md-fab md-primary md-mini" md-theme="status_{{ api.getNodeStatus(node) }}" ng-href="#/nodes/{{node.id}}">
                 <md-tooltip md-direction="bottom">
                   {{node.name}}
                 </md-tooltip>
-                <md-icon aria-label='{{node.status}}'>{{icons[node.status]}}</md-icon>
+                <md-icon aria-label='{{ api.getNodeStatus(node) }}'>{{ api.getNodeIcon(node) }}</md-icon>
               </md-button>
-
             </span>
 
         </md-tab>
@@ -102,8 +101,8 @@ deployments view
                 <tr ng-repeat="node in _nodes | from:'deployment':deployment | filter:{system: false} | orderBy:'name'">
                   <td>
                     <span>
-                      <md-icon class='status' swap-md-paint-bg="status_{{!node.alive ? 'off' : node.status}} primary" swap-md-paint-fg="status_{{!node.alive ? 'off' : node.status}} foreground">
-                        {{icons[!node.alive ? 'off' : node.status]}}
+                      <md-icon class='status' swap-md-paint-bg="status_{{ api.getNodeStatus(node) }} primary" swap-md-paint-fg="status_{{ api.getNodeStatus(node) }} foreground">
+                        {{ api.getNodeIcon(node) }}
                       </md-icon>
                       <md-tooltip>
                         {{!node.alive ? 'off' : node.status}}
@@ -180,11 +179,11 @@ deployments view
               <md-divider></md-divider>
 
               <!-- Node button -->
-              <md-button class="md-fab md-primary md-mini" md-theme="status_{{node.status}}" ng-href="#/nodes/{{node.id}}">
+              <md-button class="md-fab md-primary md-mini" md-theme="status_{{ api.getNodeStatus(node) }}" ng-href="#/nodes/{{node.id}}">
                 <md-tooltip md-direction="bottom">
                   {{node.status}}
                 </md-tooltip>
-                <md-icon aria-label='{{node.status}}'>{{icons[node.status]}}</md-icon>
+                <md-icon aria-label='{{ api.getNodeStatus(node) }}'>{{ api.getNodeIcon(node) }}</md-icon>
               </md-button>
               <span flex>
                 {{node.name}}

--- a/views/deployments.html
+++ b/views/deployments.html
@@ -270,7 +270,11 @@ deployments view
 
         <!-- Right side of toolbar -->
         <md-card-icon-actions layout-align='end center'>
-          <md-button class='md-icon-button' ng-click='deleteDeployment($event, id)'>
+          <md-button class='md-icon-button' ng-if='!deployment.system' ng-click='redeployDeployment($event, id)'>
+            <md-icon>low_priority</md-icon>
+            <md-tooltip>Redeploy All Nodes</md-tooltip>
+          </md-button>
+          <md-button class='md-icon-button' ng-if='!deployment.system' ng-click='deleteDeployment($event, id)'>
             <md-icon>delete</md-icon>
             <md-tooltip>Destroy</md-tooltip>
           </md-button>

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -11,13 +11,13 @@
         <a ng-href='#/deployments/{{node_role.deployment_id}}'  swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_deployments[node_role.deployment_id].name}}
         </a>
-        <a ng-href='#/nodes/{{node_role.node_id}}'  swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-href='#/nodes/{{node_role.node_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_nodes[node_role.node_id].name}}
         </a>
         <md-icon class='md-primary'>
           {{_roles[node_role.role_id].icon}}
         </md-icon>
-        <a ng-href='#/roles/{{node_role.role_id}}'  swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-href='#/roles/{{node_role.role_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_roles[node_role.role_id].name}}
         </a>
       </span>

--- a/views/nodes.html
+++ b/views/nodes.html
@@ -67,11 +67,11 @@
           <th md-column md-order-by='tenant_id'>Tenant</th>
         </tr>
       </thead>
-      <tbody md-body swap-md-paint-bg="status_{{ nodes.getStatus(node) }} primary" swap-md-paint-fg="status_{{ nodes.getStatus(node) }} foreground" ng-repeat="node in nodes.getNodes() | orderBy: myOrder">
+      <tbody md-body swap-md-paint-bg="status_{{ api.getNodeStatus(node) }} primary" swap-md-paint-fg="status_{{ api.getNodeStatus(node) }} foreground" ng-repeat="node in nodes.getNodes() | orderBy: myOrder">
         <tr md-row md-select="node" md-select-id="{{node.id}}" md-auto-select>
           <td md-cell>
             <md-icon>
-              {{ icons[nodes.getStatus(node)] }}
+              {{ api.getNodeIcon(node) }}
             </md-icon>
             <md-tooltip>
               {{node.available ? '' : 'Reserved'}} {{node.alive ? 'On' : 'Off'}} {{states[node.state]}}

--- a/views/nodes.html
+++ b/views/nodes.html
@@ -11,7 +11,7 @@
       <span>{{nodes.selected.length}} node{{nodes.selected.length != 1 && 's' || ''}} selected</span>
       <span flex></span>
       <md-button class='md-icon-button' ng-click='redeploySelected()'>
-        <md-icon>replay</md-icon>
+        <md-icon>low_priority</md-icon>
         <md-tooltip>Redeploy Nodes</md-tooltip>
       </md-button>
       <md-menu md-position-mode="target-right target">

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -1,9 +1,9 @@
 <md-card>
-  <md-toolbar class="md-default" md-theme='status_{{ nodes.getStatus(node) }}'>
+  <md-toolbar class="md-default" md-theme='status_{{ api.getNodeStatus(node) }}'>
     <div class="md-toolbar-tools">
       <span>
         <md-icon class='md-primary'>
-          {{ icons[nodes.getStatus(node)] }}
+          {{api.getNodeIcon(node)}}
           <md-tooltip>
             {{node.available ? '' : 'Reserved'}} {{node.status}}
           </md-tooltip>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -13,7 +13,7 @@
         {{node.name}}
       </span>
       <md-button class='md-icon-button' ng-click='redeploy()'>
-        <md-icon>replay</md-icon>
+        <md-icon>low_priority</md-icon>
         <md-tooltip>Redeploy Node</md-tooltip>
       </md-button>
       <md-menu md-position-mode="target-right target" style='padding: 0;'>

--- a/views/provider.html
+++ b/views/provider.html
@@ -121,7 +121,7 @@ provider view
 					<md-tooltip md-direction="bottom">
 						{{node.name}}
 					</md-tooltip>
-					<md-icon>{{icons[node.status]}}</md-icon>
+					<md-icon>{{ nodes.getIcon(node) }}</md-icon>
 				</md-button>
 
 			</span>


### PR DESCRIPTION
This pull has two items.  

FIRST: While the deployment role attrib edit was working correctly, it was very confusing in the dialog.

The updated behavior will better highlight when the DR needs to be committed after things are edited.  If attribs are edited then the DR is automatically proposed (and the UX shows this clearly)

NOTE: we'll get the state from the API newly exposed DR.proposed property.  Hopefully, this code will "just work" now that the property is in the API.

SECOND: Refactor the way Node status & icons are being shown.  This simplifies the code and improves handling of power and reserved states.  It also takes advantage of the NEW node.icon ready values that can be user or role settable.

Also
1) used better Icon for redeploy.
2) added redeploy for deployment
3) hid delete & redeploy on system deployments