### PR TITLE
add tenant information to deployments, add icons everywhere

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
           <span flex></span>
           <md-menu md-position-mode="target-right target" style='padding: 0;' ng-if='!provider'>
             <h2 ng-click='$mdOpenMenu($event)'>
-              {{_tenants[user.current_tenant_id].name}}
+              <md-icon aria-label="Tenant">group</md-icon> {{_tenants[user.current_tenant_id].name}}
               <md-tooltip>
                 Change Current Tenant
               </md-tooltip>

--- a/views/deployments.html
+++ b/views/deployments.html
@@ -8,15 +8,18 @@ deployments view
     <md-toolbar flex layout='column' md-theme='status_{{deploymentStates[deployment.state]}}' ng-class="{'md-warn': deployments.deploymentStatus[id].error > 0}" ng-click="deployments.toggleExpand(deployment)" md-ink-ripple>
       <section layout='row'>
         <div class="md-toolbar-tools">
-          <span>
+          <h2 flex>
             <md-icon>
               {{deploymentIcons[deploymentStates[deployment.state]]}}
             </md-icon>
             <md-tooltip>
               {{deploymentStateNames[deployment.state]}}
             </md-tooltip>
-          </span>
-          <h2 class="md-flex">{{deployment.name}}</h2>
+            {{deployment.name}}
+          </h2>
+          <h2>
+            <md-icon aria-label="Tenant">group</md-icon> {{_tenants[deployment.tenant_id].name}}
+          </h2>
         </div>
         <span flex></span>
 

--- a/views/tenants.html
+++ b/views/tenants.html
@@ -6,6 +6,7 @@ Tenants view
     <md-toolbar ng-click="expand[tenant.uuid]=!expand[tenant.uuid]" md-ink-ripple>
       <div class='md-toolbar-tools'>
         <h2 flex>
+          <md-icon aria-label="Tenant">group</md-icon>
           {{tenant.name}}
         </h2>
         <span>

--- a/views/users.html
+++ b/views/users.html
@@ -6,10 +6,11 @@ users view
   <md-toolbar ng-click="expand[user.id]=!expand[user.id]" md-ink-ripple>
     <div class="md-toolbar-tools">
       <h2 flex>
+        <md-icon aria-label="User">person</md-icon>
         {{user.username}}
       </h2>
       <h2>
-        {{_tenants[user.tenant_id].name || user.tenant_id}}
+        <md-icon aria-label="Tenant">group</md-icon> {{_tenants[user.tenant_id].name || user.tenant_id}}
       </h2>
       <span>
         <md-button class='md-icon-button'>


### PR DESCRIPTION
As prep for making tenants work better, we need to expose more tenant info in the UX.