### PR TITLE
group menus, shorten node name on matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
 
         <md-divider></md-divider>
 
-        <!-- Access menu -->
+        <!-- Management menu -->
         <div ng-repeat="item in managementMenu" ng-if='!item.hide()'>
           <md-list-item ng-click="item.expand ? item.toggleExpand() : setPath(item.path)">
             <md-icon>{{item.icon}}</md-icon>

--- a/js/app.js
+++ b/js/app.js
@@ -366,49 +366,57 @@ var version = '0.1.4';
       title: 'Networks',
       icon: 'swap_horiz',
       path: '/networks'
-    }, {
-      title: 'DNS Zones',
-      icon: 'public',
-      path: '/dns',
-      hide: function () {
-        return !$scope.showDNS; }
-    }, {
-      title: 'DHCP Subnets',
-      icon: 'device_hub',
-      path: '/dhcp',
-      hide: function () {
-        return !$scope.showDHCP; }
-    }, {
-      title: 'Rule Engine',
-      icon: 'settings_input_composite',
-      path: '/engine',
-      hide: function () {
-        return !$scope.showEngine; }
-    }, {
-      title: 'Provisioner',
-      icon: 'local_shipping',
-      hide: function () {
-        return !$scope.showProvisioner; },
-      expand: true,
-      expanded: function () {
-        return $scope.expandProvisioner; },
-      toggleExpand: $scope.toggleExpandProvisioner,
-      items: [{
-        title: 'Machines',
-        icon: 'dns',
-        path: '/provisioner/machines'
-      }, {
-        title: 'Boot Environments',
-        icon: 'album',
-        path: '/provisioner/bootenvs'
-      }, {
-        title: 'Templates',
-        icon: 'insert_drive_file',
-        path: '/provisioner/templates'
-      }]
     }];
 
     $scope.managementMenu = [{
+      title: 'Services',
+      icon: "tune",
+      expand: true,
+      expanded: function () {
+        return $scope.expandServices; },
+      toggleExpand: $scope.toggleExpandServices,
+      items: [{
+        title: 'Rule Engine',
+        icon: 'settings_input_composite',
+        path: '/engine',
+        hide: function () {
+          return !$scope.showEngine; }
+        }, {
+          title: 'DHCP Subnets',
+          icon: 'device_hub',
+          path: '/dhcp',
+          hide: function () {
+            return !$scope.showDHCP; }
+        }, {
+          title: 'DNS Zones',
+          icon: 'public',
+          path: '/dns',
+          hide: function () {
+            return !$scope.showDNS; }
+        }]
+      }, {
+        title: 'Provisioner',
+        icon: 'local_shipping',
+        hide: function () {
+          return !$scope.showProvisioner; },
+        expand: true,
+        expanded: function () {
+          return $scope.expandProvisioner; },
+        toggleExpand: $scope.toggleExpandProvisioner,
+        items: [{
+          title: 'Machines',
+          icon: 'dns',
+          path: '/provisioner/machines'
+        }, {
+          title: 'Boot Environments',
+          icon: 'album',
+          path: '/provisioner/bootenvs'
+        }, {
+          title: 'Templates',
+          icon: 'insert_drive_file',
+          path: '/provisioner/templates'
+        }]
+      }, {
       title: 'Access',
       icon: 'lock',
       expand: true,
@@ -483,6 +491,10 @@ var version = '0.1.4';
     $rootScope.lastPath = '/';
     $rootScope.shouldLogOut = false;
 
+    $rootScope.expandServices = false;
+    $rootScope.toggleExpandServices = function () {
+      $rootScope.expandServices = !$rootScope.expandServices;
+    };
     $rootScope.expandProvisioner = false;
     $rootScope.toggleExpandProvisioner = function () {
       $rootScope.expandProvisioner = !$rootScope.expandProvisioner;

--- a/js/rebar.js
+++ b/js/rebar.js
@@ -664,6 +664,12 @@
         return $rootScope.icons[ns];
     }
 
+    api.truncName = function(name) {
+      return name.substring(0,name.indexOf("."));
+    };
+
+
+
     return api;
 
   });

--- a/views/deployments.html
+++ b/views/deployments.html
@@ -110,7 +110,7 @@ deployments view
                     </span>
                   </td>
                   <td class='label'>
-                    <a ng-href='#/nodes/{{node.id}}'>{{node.name}}</a>
+                    <a ng-href='#/nodes/{{node.id}}' title="{{node.name}}">{{api.truncName(node.name)}}</a>
                   </td>
                   <td ng-repeat='id in matrix_order[deployment.id]'>
                     <span ng-if='matrix[deployment.id][id][node.id]'>


### PR DESCRIPTION
tweaks for usability - make the menus smaller as we add more stuff

also, node names were too long for cloud instances and it was making the matrix run off the screen.