### PR TITLE
Improve Role view with parent/child and retry button.  

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -461,13 +461,9 @@ var version = '0.1.4';
         icon: 'insert_link',
         path: '/api_helper'
       }, {
-        title: 'Deployment Roles',
+        title: 'Roles',
         icon: 'label_outline',
-        path: '/deployment_roles'
-      }, {
-        title: 'Node Roles',
-        icon: 'label',
-        path: '/node_roles'
+        path: '/roles'
       }, {
         title: 'Attributes',
         icon: 'list',

--- a/js/roles.js
+++ b/js/roles.js
@@ -8,7 +8,7 @@ role controller
 
     $scope.myOrder = 'jig_name';
     $scope.flags = ["library", "implicit", "bootstrap",
-      "discovery", "cluster", "destructive", "abstract"
+      "discovery", "cluster", "destructive", "abstract", "powersave"
     ];
 
     // converts the _roles object that rootScope has into an array
@@ -25,16 +25,48 @@ role controller
     $scope.role = {};
     $scope.metadata = {};
     $scope.editing = false;
+    $scope.relations = {"Parents": [], "Children": [], "Provides": [], "Conflicts": []};
     var hasCallback = false;
+
+    $scope.retry = function () {
+      for (var id in $scope._node_roles) {
+        var nr = $scope._node_roles[id];
+        if (nr.role_id == $scope.id) {
+          api('/api/v2/node_roles/' + id + '/retry', {
+            method: 'PUT'
+          })
+          .success(api.addNodeRole).success( function () {
+            api.toast('Retried Role ' + $scope.role.name + " on Node ID " + nr.node_id);
+          })
+          .error(function (err) {
+            api.toast('Error retrying node role', 'node_role', err);
+          });
+        }
+      }
+    }
 
     var updateRole = function () {
       if ($scope.editing) return;
 
       $scope.role = $scope._roles[$scope.id];
+
+      // find parents and chidlren
+      for (var id in $scope._roles) {
+        var r = $scope._roles[id];
+        if ($scope.role.requires.includes(r.name))
+          $scope.relations["Parents"].push(r);
+        else if ($scope._roles[id].requires.includes($scope.role.name))
+          $scope.relations["Children"].push(r);
+        else if ($scope.role.provides.includes(r.name))
+          $scope.relations["Provides"].push(r);
+        else if ($scope.role.conflicts.includes(r.name))
+          $scope.relations["Conflicts"].push(r);
+      }
+
       $scope.metadata = JSON.stringify($scope.role.metadata, null, "  ")
-      console.log($scope.metadata)
+      //console.log($scope.metadata)
       if (!$scope.role)
-        $location.path('/roles');
+        $location.path('/api/v2/roles');
       else if (!hasCallback) {
         hasCallback = true;
         $scope.$on('role' + $scope.role.id + "Done", updateRole);

--- a/js/workloads.js
+++ b/js/workloads.js
@@ -434,6 +434,7 @@ workloads controller
       };
 
       $scope.generateBlob = function () {
+        console.log("JSON generate starting");
         var data = {
           commit: workloads.commit,
           attribs: workloads.attribs
@@ -443,7 +444,7 @@ workloads controller
 
         if (!workloads.use_system) {
           var hints = $scope.providerMap[workloads.provider].auth_details["provider-create-hint"];
-          if (hints == null) {
+          if (!hints) {
             var ptype = $scope.providerMap[workloads.provider]["type"];
             hints = $scope.providerTemplates[ptype]["provider-create-hint"].default;
           }
@@ -452,6 +453,7 @@ workloads controller
             hints: hints,
           };
         }
+        console.log("JSON generating nodes in " + data);
 
         var virtualNodes = 0;
         data.nodes = [];
@@ -462,6 +464,7 @@ workloads controller
           var roles = [];
           var label = "node";
 
+          console.log("JSON generate adding roles to node " + node);
           for (var j in wizard.services) {
             var service = wizard.services[j];
             var hasService = serviceMap[node.id][service.name];
@@ -515,9 +518,10 @@ workloads controller
         }
 
         // If we have keys, add them here
+        console.log("JSON generate adding keys");
         for (var k in workloads.keys) {
           if (workloads.keys[k]) {
-            kvp = workloads.keys[k];
+            var kvp = workloads.keys[k];
             if (kvp && kvp[1].length > 20) {
               if (!data.public_keys) {
                 data.public_keys = {};
@@ -528,6 +532,7 @@ workloads controller
         }
 
         // If we have a role apply order, then pass it along
+        console.log("JSON generate apply order");
         if (wizard.role_apply_order && wizard.role_apply_order.length > 1) {
           data.role_apply_order = wizard.role_apply_order;
         }

--- a/views/deployment_roles.html
+++ b/views/deployment_roles.html
@@ -1,8 +1,19 @@
 <md-card>
   <md-toolbar class="md-table-toolbar md-default" ng-hide='deployment_roles.selected.length'>
     <div class="md-toolbar-tools">
-      <span>Deployment Roles ({{getDeploymentRoles().length}})</span>
-    </div>
+      <span flex>Deployment Roles ({{getDeploymentRoles().length}})</span>
+      <md-button class='md-icon-button' ng-href='#/roles'>
+        <md-icon>label_outline</md-icon>
+        <md-tooltip md-direction="bottom">
+          Roles
+        </md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-href='#/node_roles'>
+        <md-icon>dns</md-icon>
+        <md-tooltip md-direction="bottom">
+          Node Roles
+        </md-tooltip>
+      </md-button>    </div>
   </md-toolbar>
 
   <md-toolbar class="md-table-toolbar alternate" ng-show='deployment_roles.selected.length'>

--- a/views/node_roles.html
+++ b/views/node_roles.html
@@ -6,6 +6,18 @@
         <md-icon>redo</md-icon>
         <md-tooltip>Retry All</md-tooltip>
       </md-button>
+      <md-button class='md-icon-button' ng-href='#/roles'>
+        <md-icon>label_outline</md-icon>
+        <md-tooltip md-direction="bottom">
+          Roles
+        </md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-href='#/deployment_roles'>
+        <md-icon>dashboard</md-icon>
+        <md-tooltip md-direction="bottom">
+          Deployment Roles
+        </md-tooltip>
+      </md-button>
     </div>
   </md-toolbar>
 

--- a/views/roles.html
+++ b/views/roles.html
@@ -1,7 +1,22 @@
 <md-card>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
-      <span>Roles ({{getRoles().length}})</span>
+      <span flex>
+        <md-icon>label_outline</md-icon>
+        Roles ({{getRoles().length}})
+      </span>
+      <md-button class='md-icon-button' ng-href='#/node_roles'>
+        <md-icon>dns</md-icon>
+        <md-tooltip md-direction="bottom">
+          Node Roles
+        </md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-href='#/deployment_roles'>
+        <md-icon>dashboard</md-icon>
+        <md-tooltip md-direction="bottom">
+          Deployment Roles
+        </md-tooltip>
+      </md-button>
     </div>
   </md-toolbar>
 
@@ -45,17 +60,17 @@
           <td md-cell>
             <span ng-repeat="flag in flags" ng-if='role[flag]'>
             {{flag}}
-          </span>
+            </span>
           </td>
           <td md-cell>
             <span ng-repeat="provide in role.provides">
             {{provide}}
-          </span>
+            </span>
           </td>
           <td md-cell>
             <span ng-repeat="conflict in conflicts">
             {{conflict}}
-          </span>
+            </span>
           </td>
         </tr>
       </tbody>

--- a/views/roles_singular.html
+++ b/views/roles_singular.html
@@ -1,12 +1,22 @@
 <md-card>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
-      <span>
-        <md-icon>
+      <span flex>
+        <md-icon title="icon name: {{role.icon}}">
           {{role.icon}}
         </md-icon>
         {{role.name}}
       </span>
+      <md-button class='md-icon-button' ng-click='retry()'>
+        <md-icon>redo</md-icon>
+        <md-tooltip>Retry All Node Roles</md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-href='#/roles'>
+        <md-icon>label_outline</md-icon>
+        <md-tooltip md-direction="bottom">
+          Roles
+        </md-tooltip>
+      </md-button>
     </div>
   </md-toolbar>
 
@@ -31,36 +41,50 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>Source</td>
+        <td class='label'>Flags</td>
         <td>
-          <a ng-href='https://github.com/digitalrebar/core/tree/master/script/roles/{{role.name}}'>
-            https://github.com/digitalrebar/core/tree/master/script/roles/{{role.name}}
-          </a>
+          <span ng-repeat="flag in flags" ng-if='role[flag]'>
+            {{flag}}
+          </span>
         </td>
-        <tr>
-          <td class='label'>Flags</td>
-          <td>
-            <span ng-repeat="flag in flags" ng-if='role[flag]'>
-              {{flag}}
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td class='label' valign="top">Metadata</td>
-          <td>
-            <pre>{{metadata}}</pre>
-          </td>
-        </tr>
+      </tr>
     </table>
   </md-card-content>
 
+</md-card>
+
+<!-- Show Meta Data -->
+<md-card>
+  <md-card-content>
+    <table layout-padding flex width="100%">
+      <thead>
+        <tr>
+          <th align="left" ng-repeat="(name, group) in relations" ng-show="group.length>0">{{name}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td ng-repeat="(name, group) in relations" ng-show="group.length>0">
+            <span ng-repeat="r in group | orderBy: r.cohort">
+              <md-button class="md-fab md-primary" ng-href='#/roles/{{r.id}}'>
+                <md-icon>{{r.icon}}</md-icon>
+                <md-tooltip md-direction="bottom">
+                  {{r.name}}: {{r.description}}
+                </md-tooltip>
+              </md-button>
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </md-card-content>
 </md-card>
 
 <!-- Show node roles -->
 <md-card>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
-      <span>Node Roles</span>
+      <span flex>Node Roles</span>
     </div>
   </md-toolbar>
   <md-card-content>
@@ -72,5 +96,19 @@
         </md-tooltip>
       </md-button>
     </span>
-    <md-card-content>
+  </md-card-content>
+</md-card>
+
+<!-- Show Meta Data -->
+<md-card>
+  <md-toolbar class="md-table-toolbar md-default">
+    <div class="md-toolbar-tools">
+      <span flex>Metadata</span>
+    </div>
+  </md-toolbar>
+  <md-card-content>
+    <pre>
+      {{ metadata }}
+    </pre>
+  </md-card-content>
 </md-card>


### PR DESCRIPTION
Cleanups including adding navigation buttons between node_roles and deployment_roles
Moved them off the advanced menu in favor of the higher level roles list.

The parents view requires the roles.requires patch on core.

TODO: Add attribs & wanted_attribs.