### PR TITLE
add help link for node role failures

### DIFF
--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -141,6 +141,7 @@ node role controller
     $scope.hasAttrib = -1;
     $scope.attribs = [];
     $scope.editing = false;
+    $scope.helplink = "http://digital-rebar.readthedocs.io/en/latest/deployment/troubleshooting/roles";
     var hasCallback = false;
 
     var updateNodeRole = function () {

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -43,7 +43,14 @@
       <h2>Node Role</h2>
     </div>
   </md-toolbar>
-
+  <div class="md-toolbar-tools" ng-show="node_role.state<0">
+    <span>
+      <a target="_new" href="{{helplink + '/' + _roles[node_role.role_id].name + '.html'}}">
+        <md-icon>help</md-icon>
+        Role Troubleshooting Help
+      </a>
+    </span>
+  </div>
   <div class="md-toolbar-tools">
     <span>Attributes</span>
   </div>


### PR DESCRIPTION
does not require, but works with https://github.com/digitalrebar/doc/pull/153 