### PR TITLE
add proto-type switch rendering code

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
     <script src="js/deployment_roles.js"></script>
     <script src="js/barclamps.js"></script>
     <script src="js/networks.js"></script>
+    <script src="js/switches.js"></script>
     <script src="js/provider.js"></script>
     <script src="js/nnealer.js"></script>
     <script src="js/users.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -150,6 +150,11 @@ var version = '0.1.4';
       controllerAs: 'networks',
       templateUrl: 'views/networks_singular.html'
     }).
+    when('/switches', {
+      controller: 'SwitchesCtrl',
+      controllerAs: 'switches',
+      templateUrl: 'views/switches.html'
+    }).
     when('/providers', {
       controller: 'ProviderCtrl',
       controllerAs: 'providers',

--- a/js/switches.js
+++ b/js/switches.js
@@ -1,0 +1,108 @@
+/*
+switch controller
+*/
+(function () {
+  angular.module('app').controller('SwitchesCtrl', function ($scope, $location, debounce, $routeParams, $mdMedia, $mdDialog, api) {
+
+    $scope.$emit('title', 'Switches'); // shows up on the top toolbar
+
+    $scope.sweetches = {};
+    $scope.layout = [];
+    for (var p=1; p<49; p+=2)
+      $scope.layout.push(p);
+
+    $scope.$on('nodesDone', function () {
+      // converts the _nodes object that rootScope has into an array
+      var nodes = [];
+      // collect nodes of interest
+      for (var id in $scope._nodes) {
+        if (!$scope._nodes[id].system)
+          nodes.push($scope._nodes[id].id);
+      }
+      for (var nid in nodes) {
+        api("/api/v2/nodes/" + nodes[nid] + "/attribs/ports").
+        success(function (value) {
+          // remove non-action power options
+          var node = $scope._nodes[value.node_id];
+          if (typeof value.value.lldp === "undefined" ) {
+            console.log("switches: missing lldp data for node " + node.id + " using fake data for testing");
+            value.value = $scope.fakeValue(node.id);
+          }
+          for (var nic in value.value.lldp) {
+            var sw = value.value.lldp[nic].chassis.mac;
+            var raw = value.value.lldp[nic].port.descr;
+            var ports = raw.match(/([0-9]*)\/([0-9]*)\/([0-9]*)/);
+            var port = parseInt(ports[3])
+            //console.log(sw);
+            //console.log(nic); 
+            //console.log(port);
+
+            if (!$scope.sweetches[sw]) {
+              var ports = {}
+              for (var p=1; p<49; p++)
+                ports[p] = [];
+              $scope.sweetches[sw] = { switch: { mac: sw, description: value.value.lldp[nic].chassis.descr }, ports: ports};
+            }
+            if (!$scope.sweetches[sw][port]) {
+              $scope.sweetches[sw].ports[port] = [];
+            }
+            nodemap = { id: node.id, name: node.name, nic: nic };
+            $scope.sweetches[sw].ports[port].push(nodemap);
+          }
+        });
+      };
+    });
+
+    $scope.fakeValue = function (node_id) {
+      return {
+        "lldp": {
+          "eth0": {
+            "age": "0 day, 00:00:58",
+            "chassis": {
+              "Bridge": {
+                "enabled": "on"
+              },
+              "Router": {
+                "enabled": "on"
+              },
+              "descr": "Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 13.2X51-D38, Build date: 2015-06-12 02:33:47 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.",
+              "mac": ( node_id % 2 == 0 ? "20:4e:71:32:ca:fe" : "20:4e:71:32:be:ef"),
+              "mgmt-ip": "192.168.105.2",
+              "ttl": "120"
+            },
+            "port": {
+              "descr": "xe-0/0/" + node_id % 48 + ":1",
+              "local": "2" + node_id,
+            },
+            "rid": "1",
+            "via": "LLDP"
+          },
+        "eth1": {
+            "age": "0 day, 00:00:58",
+            "chassis": {
+              "Bridge": {
+                "enabled": "on"
+              },
+              "Router": {
+                "enabled": "on"
+              },
+              "descr": "Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 13.2X51-D38, Build date: 2015-06-12 02:33:47 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.",
+              "mac": ( node_id % 2 == 0 ? "20:4e:71:32:be:ef" : "20:4e:71:32:ca:fe"),
+              "mgmt-ip": "192.168.105.2",
+              "ttl": "120"
+            },
+            "port": {
+              "descr": "xe-0/0/" + (node_id+24) % 48 + ":1",
+              "local": "3" + node_id,
+            },
+            "rid": "1",
+            "via": "LLDP"
+          }
+        },
+        "status": "Success"
+      };
+    }
+
+  });
+
+})();

--- a/views/switches.html
+++ b/views/switches.html
@@ -1,0 +1,43 @@
+<md-card>
+
+  <md-card-content ng-repeat="sw in sweetches">
+    <h1>
+      <md-icon>settings_ethernet</md-icon>
+      {{ sw.switch.mac }}
+    </h1>
+    <span>{{ sw.switch.description }}</span>
+
+    <table layout-padding border=1>
+      <tbody>
+        <tr align="center">
+          <td width="4%" ng-repeat="p in layout">{{p}}</td></tr>
+        <tr><td ng-repeat="p in layout">
+          <div ng-repeat="node in sw.ports[p]">
+            <md-button class="md-fab md-primary md-mini" md-theme="status_{{ api.getNodeStatus(_nodes[node.id]) }}" ng-href="#/nodes/{{node.id}}">
+              <md-tooltip md-direction="bottom">
+                {{node.name}}: {{node.nic}}
+              </md-tooltip>
+              <md-icon aria-label='{{ api.getNodeStatus(_nodes[node.id]) }}'>
+                {{ api.getNodeIcon(_nodes[node.id]) }}
+              </md-icon>
+            </md-button>
+          </div>
+          </td></tr>
+        <tr align="center">
+          <td ng-repeat="p in layout">{{p+1}}</td></tr>
+        <tr><td ng-repeat="p in layout">
+          <div ng-repeat="node in sw.ports[p+1]">
+            <md-button class="md-fab md-primary md-mini" md-theme="status_{{ api.getNodeStatus(_nodes[node.id]) }}" ng-href="#/nodes/{{node.id}}">
+              <md-tooltip md-direction="bottom">
+                {{node.name}}: {{node.nic}}
+              </md-tooltip>
+              <md-icon aria-label='{{ api.getNodeStatus(_nodes[node.id]) }}'>
+                {{ api.getNodeIcon(_nodes[node.id]) }}
+              </md-icon>
+            </md-button>
+          </div>
+          </td></tr>
+      </tbody>
+    </table>
+  </md-card-content>
+</md-card>


### PR DESCRIPTION
not in menus yet but accesssible from /switches

this will create fake data if the data is missing (e.g. VMs or cloud instances).
there are likely many edge cases that have to be handled; however this is enough to start testing and showing switch rendering.

![switchpull](https://cloud.githubusercontent.com/assets/724948/19420841/907559f2-93b9-11e6-8475-c244e0d239b6.PNG)
