### PR TITLE
Add Profile Editing for Node (and profiles on create)

### DIFF
--- a/js/dialog.js
+++ b/js/dialog.js
@@ -99,12 +99,12 @@ dialog controller
         'description': locals.description1,
         'profiles': locals.profiles1
       };
-      console.log(payload);
       api('/api/v2/nodes/' + locals.id, {
         method: 'PUT',
         data: payload
       }).success(function (update) {
         api.toast('Updated Node ' + locals.node.name);
+        api.addNode;
         $mdDialog.hide();
       }).error(function (err) {
         api.toast('Error Updating Node', 'node', err);

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -106,6 +106,7 @@ dialog controller
         'name': locals.base_name + "." + provider + ".neode.org",
         'description': "created by rebar",
         'provider': provider,
+        'profiles': profiles,
         'deployment_id': locals.deployment_id,
         'hints': {
           'use-proxy': false,

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -95,10 +95,11 @@ dialog controller
 
     this.updateNode= function() {
       var payload = {
-        name: locals.name,
-        description: locals.description,
-        profiles: locals.profiles
+        'name': locals.name1,
+        'description': locals.description1,
+        'profiles': locals.profiles1
       };
+      console.log(payload);
       api('/api/v2/nodes/' + locals.id, {
         method: 'PUT',
         data: payload

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -30,8 +30,8 @@ dialog controller
 
     $scope.providers = (function () {
       var providers = [];
-      for (var id in locals.providers) {
-        var provider = locals.providers[id];
+      for (var id in locals._providers) {
+        var provider = locals._providers[id];
         if (Object.keys(provider.auth_details).length)
           providers.push(provider);
       }
@@ -40,8 +40,8 @@ dialog controller
 
     $scope.providerMap = (function () {
       var pm = {};
-      for (var i in locals.providers) {
-        var provider = locals.providers[i];
+      for (var i in locals._providers) {
+        var provider = locals._providers[i];
           pm[provider.name] = provider;
           if (provider.type === 'MetalProvider' || provider.type == '') {
             continue;
@@ -93,6 +93,23 @@ dialog controller
       $mdDialog.hide();
     };
 
+    this.updateNode= function() {
+      var payload = {
+        name: locals.name,
+        description: locals.description,
+        profiles: locals.profiles
+      };
+      api('/api/v2/nodes/' + locals.id, {
+        method: 'PUT',
+        data: payload
+      }).success(function (update) {
+        api.toast('Updated Node ' + locals.node.name);
+        $mdDialog.hide();
+      }).error(function (err) {
+        api.toast('Error Updating Node', 'node', err);
+      });
+    };
+
     this.editNodesInHelper = function () {
       var provider = locals.providers[locals.provider].name;
 
@@ -130,19 +147,19 @@ dialog controller
     this.addNodes = function () {
       // create a list of `locals.number` numbers 
       var times = Array.apply(null, { length: locals.number }).map(Number.call, Number);
-      var provider = locals.providers[locals.provider].name;
+      var provider = locals._providers[locals.provider].name;
+      var hints = $scope.providerMap[provider].auth_details["provider-create-hint"];
+      if (hints == null) {
+        var ptype = $scope.providerMap[provider]["type"];
+        hints = $rootScope.providerTemplates[ptype]["provider-create-hint"].default;
+      }
 
       times.forEach(function (i) {
-        var hints = $scope.providerMap[provider].auth_details["provider-create-hint"];
-        if (hints == null) {
-          var ptype = $scope.providerMap[provider]["type"];
-          hints = $rootScope.providerTemplates[ptype]["provider-create-hint"].default;
-        }
-
         var payload = {
           'name': locals.base_name + "-" + i + "." + provider + ".neode.org",
           'description': "created by rebar",
           'provider': provider,
+          'profiles': locals.profiles,
           'deployment_id': locals.deployment_id,
           'hints': {
             'use-proxy': false,

--- a/js/nodes.js
+++ b/js/nodes.js
@@ -117,9 +117,9 @@ node controller
         locals: {
           _profiles: $scope.rawProfiles(node.profiles),
           node: node,
-          name: new String(node.name),
-          descripion: new String(node.descripion),
-          profiles: new Array(node.profiles),
+          name1: node.name,
+          descripion1: node.descripion,
+          profiles1: node.profiles,
           id: node.id
         },
         clickOutsideToClose: true,

--- a/js/nodes.js
+++ b/js/nodes.js
@@ -85,10 +85,30 @@ node controller
         targetEvent: ev,
         locals: {
           base_name: 'digital-rebar-node',
-          providers: $scope._providers,
+          _providers: $scope._providers,
+          _profiles: $scope._profiles,
+          profiles: ["foo"],
           add_os: 'default_os',
           number: 1,
           _deployments: $scope._deployments
+        },
+        clickOutsideToClose: true,
+        fullscreen: useFullScreen
+      });
+    };
+
+    this.showEditNodeDialog = function (ev, node) {
+      var useFullScreen = ($mdMedia('sm') || $mdMedia('xs'));
+      console.log(node);
+      $mdDialog.show({
+        controller: 'DialogController',
+        controllerAs: 'dialog',
+        templateUrl: 'views/dialogs/editnodedialog.tmpl.html',
+        parent: angular.element(document.body),
+        targetEvent: ev,
+        locals: {
+          node: node,
+          _profiles: $scope._profiles
         },
         clickOutsideToClose: true,
         fullscreen: useFullScreen

--- a/js/nodes.js
+++ b/js/nodes.js
@@ -118,7 +118,7 @@ node controller
           _profiles: $scope.rawProfiles(node.profiles),
           node: node,
           name1: node.name,
-          descripion1: node.descripion,
+          description1: node.description,
           profiles1: node.profiles,
           id: node.id
         },

--- a/js/nodes.js
+++ b/js/nodes.js
@@ -75,6 +75,15 @@ node controller
       });
     };
 
+    $scope.rawProfiles = function(current) {
+      raw = [];
+      for (var i in $scope._profiles) {
+        if (!current.includes($scope._profiles[i].name))
+          raw.push($scope._profiles[i].name);
+      }
+      return raw;
+    };
+
     this.showAddNodeDialog = function (ev) {
       var useFullScreen = ($mdMedia('sm') || $mdMedia('xs'));
       $mdDialog.show({
@@ -86,8 +95,8 @@ node controller
         locals: {
           base_name: 'digital-rebar-node',
           _providers: $scope._providers,
-          _profiles: $scope._profiles,
-          profiles: ["foo"],
+          _profiles: $scope.rawProfiles([]),
+          profiles: [],
           add_os: 'default_os',
           number: 1,
           _deployments: $scope._deployments
@@ -99,7 +108,6 @@ node controller
 
     this.showEditNodeDialog = function (ev, node) {
       var useFullScreen = ($mdMedia('sm') || $mdMedia('xs'));
-      console.log(node);
       $mdDialog.show({
         controller: 'DialogController',
         controllerAs: 'dialog',
@@ -107,8 +115,12 @@ node controller
         parent: angular.element(document.body),
         targetEvent: ev,
         locals: {
+          _profiles: $scope.rawProfiles(node.profiles),
           node: node,
-          _profiles: $scope._profiles
+          name: new String(node.name),
+          descripion: new String(node.descripion),
+          profiles: new Array(node.profiles),
+          id: node.id
         },
         clickOutsideToClose: true,
         fullscreen: useFullScreen

--- a/views/dialogs/addnodedialog.tmpl.html
+++ b/views/dialogs/addnodedialog.tmpl.html
@@ -54,7 +54,7 @@
           <section layout-padding ng-hide="locals._profiles.length > 0">
             No Profiles Available
           </section>
-          <section layout-padding style='overflow-x: auto;' ng-show="locals._profiles.length > 0">
+          <section layout-padding style='overflow-x: auto;' ng-if="locals._profiles.length > 0">
             <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
               <md-chip-template style='font-family: monospace;'>
                 {{ $chip }}

--- a/views/dialogs/addnodedialog.tmpl.html
+++ b/views/dialogs/addnodedialog.tmpl.html
@@ -26,7 +26,7 @@
         <md-input-container class='md-block'>
           <label>Provider</label>
           <md-select required name='provider' ng-model="locals.provider">
-            <md-option ng-repeat="provider in providers" value="{{provider.id}}">
+            <md-option ng-repeat="provider in locals._providers" value="{{provider.id}}" ng-if="!['metal','phantom'].includes(provider.name)">
               {{provider.name}}
             </md-option>
           </md-select>
@@ -35,7 +35,7 @@
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block' style='padding-bottom: 16px;'>
+        <md-input-container class='md-block'>
           <label>Deployment</label>
           <md-select required name='deployment_id' ng-model="locals.deployment_id">
             <md-option ng-repeat="(id, deployment) in locals._deployments" value="{{id}}">
@@ -50,6 +50,21 @@
           </div>
         </md-input-container>
 
+        ZEHICLE <div ng-repeat="item in locals._profiles">{{ item.name }}|</div>
+        <md-input-container class='md-block' style='padding-bottom: 16px;'>
+          <section layout-padding style='overflow-x: auto;'>
+            <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
+              <md-chip-template style='font-family: monospace;'>
+                {{ $chip }}
+              </md-chip-template>
+              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item.name" placeholder="Add Profiles">
+                <span md-highlight-text="searchText">
+                  {{item.name}}
+                </span>
+              </md-autocomplete>
+            </md-chips>
+          </section>
+        </md-input-container>
 
         <md-input-container class='md-block'>
           <label>Number</label>

--- a/views/dialogs/addnodedialog.tmpl.html
+++ b/views/dialogs/addnodedialog.tmpl.html
@@ -50,19 +50,21 @@
           </div>
         </md-input-container>
 
-        ZEHICLE <div ng-repeat="item in locals._profiles">{{ item.name }}|</div>
         <md-input-container class='md-block' style='padding-bottom: 16px;'>
-          <section layout-padding style='overflow-x: auto;'>
+          <section layout-padding ng-hide="locals._profiles.length > 0">
+            No Profiles Available
+          </section>
+          <section layout-padding style='overflow-x: auto;' ng-show="locals._profiles.length > 0">
             <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
               <md-chip-template style='font-family: monospace;'>
                 {{ $chip }}
               </md-chip-template>
-              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item.name" placeholder="Add Profiles">
+              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item" placeholder="Add Profiles">
                 <span md-highlight-text="searchText">
-                  {{item.name}}
+                  {{item}}
                 </span>
               </md-autocomplete>
-            </md-chips>
+            </md-chips>          
           </section>
         </md-input-container>
 

--- a/views/dialogs/editnodedialog.tmpl.html
+++ b/views/dialogs/editnodedialog.tmpl.html
@@ -1,0 +1,58 @@
+<md-dialog aria-label="Edit Node" ng-cloak flex-gt-sm='50'>
+  <form name='nodeForm'>
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <h2>Edit Node {{locals.node.name}}</h2>
+        <span flex></span>
+        <md-button class="md-icon-button" ng-click="cancel()">
+          <md-icon>close</md-icon>
+        </md-button>
+      </div>
+    </md-toolbar>
+
+    <md-dialog-content layout-padding>
+      <md-content>
+        <md-input-container class='md-block'>
+          <label>Name</label>
+          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.node.name' />
+          <div ng-messages="nodeForm.name.$error">
+            <div ng-message="required">Enter a node name</div>
+            <div ng-message="md-maxlength">Entered name is too long (25 char max)</div>
+            <div ng-message="md-minlength">Entered name is too short (1 char min)</div>
+            <div ng-message="pattern">Entered name contains invalid characters (a-zA-Z0-9-)</div>
+          </div>
+        </md-input-container>
+
+        <md-input-container class='md-block'>
+          <label>Description</label>
+          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.node.description' />
+          <div ng-messages="nodeForm.name.$error">
+            <div ng-message="md-maxlength">Entered name is too long (80 char max)</div>
+          </div>
+        </md-input-container>
+
+        ZEHICLE <div ng-repeat="item in locals._profiles">{{ item.name }}|</div>
+        <md-input-container class='md-block' style='padding-bottom: 16px;'>
+          <section layout-padding style='overflow-x: auto;'>
+            <md-chips ng-model='locals.node.profiles' placeholder='Profiles (optional)' md-require-match="true">
+              <md-chip-template style='font-family: monospace;'>
+                {{ $chip }}
+              </md-chip-template>
+              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item.name" placeholder="Add Profiles">
+                <span md-highlight-text="searchText">
+                  {{item.name}}
+                </span>
+              </md-autocomplete>
+            </md-chips>
+          </section>
+        </md-input-container>
+
+      </md-content>
+    </md-dialog-content>
+    <md-dialog-actions>
+      <md-button ng-click='dialog.updateNodes()' ng-disabled='nodeForm.$error.required' class='md-primary md-raised' target="_blank" md-autofocus>
+        save
+      </md-button>
+    </md-dialog-actions>
+  </form>
+</md-dialog>

--- a/views/dialogs/editnodedialog.tmpl.html
+++ b/views/dialogs/editnodedialog.tmpl.html
@@ -14,10 +14,10 @@
       <md-content>
         <md-input-container class='md-block'>
           <label>Name</label>
-          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.name1' />
-          <div ng-messages="nodeForm.name.$error">
+          <input required type='text' name='name1' md-minlength='1' md-maxlength='60' ng-pattern="/^[a-zA-Z0-9-.]{1,60}$/" ng-model='locals.name1' />
+          <div ng-messages="nodeForm.name1.$error">
             <div ng-message="required">Enter a node name</div>
-            <div ng-message="md-maxlength">Entered name is too long (25 char max)</div>
+            <div ng-message="md-maxlength">Entered name is too long (60 char max)</div>
             <div ng-message="md-minlength">Entered name is too short (1 char min)</div>
             <div ng-message="pattern">Entered name contains invalid characters (a-zA-Z0-9-)</div>
           </div>
@@ -25,7 +25,7 @@
 
         <md-input-container class='md-block'>
           <label>Description</label>
-          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.description1' />
+          <input required type='text' name='description1' md-required="false" md-maxlength='80' ng-model='locals.description1' />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="md-maxlength">Entered name is too long (80 char max)</div>
           </div>
@@ -35,7 +35,7 @@
           <section layout-padding ng-hide="locals._profiles.length > 0">
             No Profiles Available
           </section>
-          <section layout-padding style='overflow-x: auto;' ng-show="locals._profiles.length > 0">
+          <section layout-padding style='overflow-x: auto;' ng-if="locals._profiles.length > 0">
             <md-chips ng-model='locals.profiles1' placeholder='Profiles (optional)' md-require-match="true">
               <md-chip-template style='font-family: monospace;'>
                 {{ $chip }}

--- a/views/dialogs/editnodedialog.tmpl.html
+++ b/views/dialogs/editnodedialog.tmpl.html
@@ -14,7 +14,7 @@
       <md-content>
         <md-input-container class='md-block'>
           <label>Name</label>
-          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.name' />
+          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.name1' />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="required">Enter a node name</div>
             <div ng-message="md-maxlength">Entered name is too long (25 char max)</div>
@@ -25,7 +25,7 @@
 
         <md-input-container class='md-block'>
           <label>Description</label>
-          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.description' />
+          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.description1' />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="md-maxlength">Entered name is too long (80 char max)</div>
           </div>
@@ -36,7 +36,7 @@
             No Profiles Available
           </section>
           <section layout-padding style='overflow-x: auto;' ng-show="locals._profiles.length > 0">
-            <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
+            <md-chips ng-model='locals.profiles1' placeholder='Profiles (optional)' md-require-match="true">
               <md-chip-template style='font-family: monospace;'>
                 {{ $chip }}
               </md-chip-template>

--- a/views/dialogs/editnodedialog.tmpl.html
+++ b/views/dialogs/editnodedialog.tmpl.html
@@ -14,7 +14,7 @@
       <md-content>
         <md-input-container class='md-block'>
           <label>Name</label>
-          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.node.name' />
+          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.name' />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="required">Enter a node name</div>
             <div ng-message="md-maxlength">Entered name is too long (25 char max)</div>
@@ -25,22 +25,24 @@
 
         <md-input-container class='md-block'>
           <label>Description</label>
-          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.node.description' />
+          <input required type='text' name='name' md-required="false" md-maxlength='80' ng-model='locals.description' />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="md-maxlength">Entered name is too long (80 char max)</div>
           </div>
         </md-input-container>
 
-        ZEHICLE <div ng-repeat="item in locals._profiles">{{ item.name }}|</div>
         <md-input-container class='md-block' style='padding-bottom: 16px;'>
-          <section layout-padding style='overflow-x: auto;'>
-            <md-chips ng-model='locals.node.profiles' placeholder='Profiles (optional)' md-require-match="true">
+          <section layout-padding ng-hide="locals._profiles.length > 0">
+            No Profiles Available
+          </section>
+          <section layout-padding style='overflow-x: auto;' ng-show="locals._profiles.length > 0">
+            <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
               <md-chip-template style='font-family: monospace;'>
                 {{ $chip }}
               </md-chip-template>
-              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item.name" placeholder="Add Profiles">
+              <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item" placeholder="Add Profiles">
                 <span md-highlight-text="searchText">
-                  {{item.name}}
+                  {{item}}
                 </span>
               </md-autocomplete>
             </md-chips>
@@ -50,7 +52,7 @@
       </md-content>
     </md-dialog-content>
     <md-dialog-actions>
-      <md-button ng-click='dialog.updateNodes()' ng-disabled='nodeForm.$error.required' class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click='dialog.updateNode()' ng-disabled='nodeForm.$error.required' class='md-primary md-raised' target="_blank" md-autofocus>
         save
       </md-button>
     </md-dialog-actions>

--- a/views/nodes.html
+++ b/views/nodes.html
@@ -5,7 +5,6 @@
       <span flex></span>
     </div>
   </md-toolbar>
-
   <md-toolbar class="md-table-toolbar alternate" ng-show='nodes.selected.length'>
     <div class="md-toolbar-tools">
       <span>{{nodes.selected.length}} node{{nodes.selected.length != 1 && 's' || ''}} selected</span>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -189,7 +189,7 @@
   </md-toolbar>
   <md-card-content>
     <span ng-repeat="role in _node_roles | from:'node':node | orderBy: role.cohort()">
-      <md-button class="md-fab md-primary" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
+      <md-button class="md-fab md-primary" aria-label="role" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
         <md-tooltip md-direction="bottom">{{_roles[role.role_id].name}}</md-tooltip>
         <md-icon>{{_roles[role.role_id].icon}}</md-icon>
       </md-button>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -65,6 +65,10 @@
   <md-card-content>
     <table layout-padding>
       <tr>
+        <td class='label'>Description</td>
+        <td>{{ (node.description.length > 0 ? node.description : "[not set]") }}</td>
+      </tr>
+      <tr>
         <td class='label'>Deployment</td>
         <td>
           <a ng-href='#/deployments/{{node.deployment_id}}'>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -55,6 +55,10 @@
         <md-icon>delete</md-icon>
         <md-tooltip>Delete Node</md-tooltip>
       </md-button>
+      <md-button class='md-icon-button' ng-click='nodes.showEditNodeDialog($event, node)'>
+        <md-icon>mode_edit</md-icon>
+        <md-tooltip>Edit Node</md-tooltip>
+      </md-button>
     </div>
   </md-toolbar>
 
@@ -141,7 +145,16 @@
           <a ng-href='#/providers/{{node.provider_id}}'>{{_providers[node.provider_id].name}}</a>
         </td>
       </tr>
+      <tr>
+        <td class='label'><a ng-href='#/profiles'>Profile(s)</a></td>
+        <td>
+          <span ng-repeat="p in node.profiles | orderBy: p">
+            {{p}}{{ $last ? '' : ", "}}
+          </span>
+        </td>
+      </tr>
     </table>
+
     <!-- Show Networks ONLY FOR METAL PROVIDER -->
     <div ng-show="nics != {}">
       <span class='label'>
@@ -160,6 +173,7 @@
         </li>
       </ul>
     </div>
+  </md-card-content>
 </md-card>
 
 <!-- Show node roles -->
@@ -171,11 +185,9 @@
   </md-toolbar>
   <md-card-content>
     <span ng-repeat="role in _node_roles | from:'node':node | orderBy: role.cohort()">
-      <md-button class="md-fab md-primary" aria-label="{{_roles[role.role_id].name}}" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
+      <md-button class="md-fab md-primary" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
+        <md-tooltip md-direction="bottom">{{_roles[role.role_id].name}}</md-tooltip>
         <md-icon>{{_roles[role.role_id].icon}}</md-icon>
-        <md-tooltip md-direction="bottom">
-          {{_roles[role.role_id].name}}
-        </md-tooltip>
       </md-button>
     </span>
   </md-card-content>


### PR DESCRIPTION
This patch allows users to edit node name, description and profile for the first time!

It also adds profile to the node create options.
If fixes some variable naming in the dialog path

WARNING: The profile edit does NOT work due to an API issue - the change is submitted to the API but the profile is not updated.  This could be format or an API issue.
