### PR TITLE
correct missed _ when called from providers

### DIFF
--- a/js/provider.js
+++ b/js/provider.js
@@ -122,7 +122,7 @@ provider controller
           targetEvent: ev,
           locals: {
             base_name: 'digital-rebar-node',
-            providers: $scope._providers,
+            _providers: $scope._providers,
             provider: $scope.provider.name,
             add_os: 'default_os',
             number: 1,


### PR DESCRIPTION
needs to use the same syntax as the add from the nodes list.