### PR TITLE
Performance Tune UX for polling & node roles runlog

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
               </md-menu-item>
             </md-menu-content>
           </md-menu>
-          <md-button class="md-icon-button" ng-click='api.reload()'>
+          <md-button class="md-icon-button" ng-click='api.reload()' ng-model-options="{ debounce: 500 }">
             <md-tooltip>
               Refresh Data
             </md-tooltip>

--- a/js/rebar.js
+++ b/js/rebar.js
@@ -62,6 +62,7 @@
 
     $rootScope._pollTimer;
     $rootScope._pollRate = 15;
+    $rootScope._pollRateOverride = false;
     $rootScope._deployments = {};
     $rootScope._deployment_roles = {};
     $rootScope._roles = {};
@@ -239,7 +240,10 @@
     };
 
     api.fetch = function (name, id) {
-      return api("/api/v2/" + name + "s/" + id).
+      headers = {};
+      if (name == 'node_role')
+        headers = { 'headers': {'x-return-attributes':'["id","name","deployment_id","role_id","node_id","state","cohort","run_count","status","available","order","created_at","updated_at","uuid","tenant_id","node_error"]'}};
+      return api("/api/v2/" + name + "s/" + id, headers).
       success(function (obj) {
         api["add" + camelCase(name)](obj);
       }).
@@ -266,6 +270,7 @@
         api.fetch(name, id).
         success(api.nextQueue).
         error(api.nextQueue);
+
       });
     };
 
@@ -278,15 +283,18 @@
         );
       } else { // queue is empty, wait and populate it
         api.queueLen = 0;
-        api.pollRate($rootScope._pollRate);
+        $rootScope._pollTimer = $timeout(api.getActive, $rootScope._pollRate * 1000);
       }
     };
 
-    api.pollRate = function(prate) {
-      $timeout.cancel($rootScope.pollTimer);
-      $rootScope.pollTimer = $timeout(api.getActive, prate * 1000);
-      console.log("Polling Rate set to " + prate);
-      $rootScope._pollRate = prate;
+    api.pollRate = function(rate, override) {
+      if (override && !$rootScope._pollRateOverride)
+        $rootScope._pollRateOverride = true;
+      if ($rootScope._pollRate != rate) {
+        $timeout.cancel($rootScope._pollTimer);
+        $rootScope._pollRate = rate;
+      }
+      console.debug("Polling Rate set to " + $rootScope._pollRate + " (override " + $rootScope._pollRateOverride + ")");
     };
 
     api.getActive = function () {
@@ -533,10 +541,12 @@
       $rootScope._nodes[id] = node;
       $rootScope.$broadcast("node" + id + "Done");
       // slow down polling for large systems
-      if (Object.keys($rootScope._nodes).length > 25)
-        api.pollRate(45);
-      else if (Object.keys($rootScope._nodes).length > 50)
-        api.pollRate(30);
+      if (!$rootScope._pollRateOverride) {
+        if (Object.keys($rootScope._nodes).length > 25)
+          api.pollRate(45, false);
+        else if (Object.keys($rootScope._nodes).length > 50)
+          api.pollRate(30, false);
+      }
     };
 
     // api call for getting all the nodes
@@ -645,7 +655,8 @@
     api.addNodeRole = function (role) {
       var id = role.id;
       role.status = $rootScope.states[role.state];
-
+      // should be missing, but just in case we keep from storing the bulky part of the object
+      delete role['runlog'];
       delete $rootScope._node_roles[id];
       $rootScope._node_roles[id] = role;
       $rootScope.$broadcast("node_role" + id + "Done");
@@ -653,7 +664,9 @@
 
     // api call for getting all the node roles
     api.getNodeRoles = function () {
-      return api('/api/v2/node_roles').
+      // headers does NOT include runlog to improve performance
+      return api('/api/v2/node_roles',
+        { 'headers': {'x-return-attributes':'["id","name","deployment_id","role_id","node_id","state","cohort","run_count","status","available","order","created_at","updated_at","uuid","tenant_id","node_error"]'}}).
       success(function (data) {
         $rootScope._node_roles = {};
         data.map(api.addNodeRole);

--- a/js/rebar.js
+++ b/js/rebar.js
@@ -293,8 +293,8 @@
       if ($rootScope._pollRate != rate) {
         $timeout.cancel($rootScope._pollTimer);
         $rootScope._pollRate = rate;
+        console.debug("Polling Rate set to " + $rootScope._pollRate + " (override " + $rootScope._pollRateOverride + ")");
       }
-      console.debug("Polling Rate set to " + $rootScope._pollRate + " (override " + $rootScope._pollRateOverride + ")");
     };
 
     api.getActive = function () {

--- a/views/annealer.html
+++ b/views/annealer.html
@@ -1,8 +1,12 @@
 <div class="md-toolbar-tools">
 	<span flex> </span>
 	<span class='pull-right'>
-		Poll Rate: <input ng-model='_pollRate' min=5 max=300 type='number' ng-change='api.pollRate(_pollRate)' /> seconds
+		Background Poll Rate: <input aria-label='poll rate' ng-model='_pollRate' min=5 max=300 type='number' ng-change='api.pollRate(_pollRate, true)' /> seconds
 	</span>
+	<md-button class='md-icon-button' ng-click='api.getActive()'>
+	  <md-icon>autorenew</md-icon>
+	  <md-tooltip>Refresh Annealer Queue</md-tooltip>
+	</md-button>
 </div>
 <md-card ng-repeat="status in statesList">
   <md-toolbar md-theme="status_{{getNodeRoles(status).length ? status : 'off'}}">

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -60,11 +60,14 @@
 </md-card>
 
 <!-- Run Log -->
-<md-card ng-if='node_role.runlog'>
+<md-card>
   <md-toolbar class="md-table-toolbar md-default" id='runlog'>
     <div class="md-toolbar-tools">
       <h2 flex>Run Log</h2>
-      <md-button clipboard class='md-icon-button' supported='supported' text="node_role.runlog" on-copied='onCopy(true)' on-error='onCopy(false, err)'>
+      <span class='pull-right' ng-if="node_role.state!=0">
+        Refresh <input ng-model='pollLog' min=1 max=30 type='number' ng-change='changeRate(pollLog)'/> seconds
+      </span>
+      <md-button clipboard class='md-icon-button' supported='supported' text="runlog" on-copied='onCopy(true)' on-error='onCopy(false, err)'>
         <md-icon>
           content_paste
         </md-icon>
@@ -75,6 +78,6 @@
     </div>
   </md-toolbar>
   <md-card-content>
-    <pre class='runlog'>{{node_role.runlog}}</pre>
+    <pre class='runlog'>{{runlog}}</pre>
   </md-card-content>
 </md-card>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -28,9 +28,9 @@
         <md-menu-content width="4">
           <md-menu-item ng-repeat="role in getRoles() | orderBy:'name'">
             <md-button aria-label="{{ _roles[role.id].name }}" ng-click="bindNodeRole(role.role_id)">
-              <md-tooltip>{{ _roles[role.id].description }}</md-tooltip>
               <md-icon md-menu-align-target style="margin: auto 3px auto 0;">{{_roles[role.id].icon}}</md-icon>
               <md-title>{{ _roles[role.id].name }}</md-title>
+              <md-tooltip>{{ _roles[role.id].description }}</md-tooltip>
             </md-button>
           </md-menu-item>
           <md-menu-item ng-if='getRoles().length == 0'>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -27,9 +27,10 @@
         </md-button>
         <md-menu-content width="4">
           <md-menu-item ng-repeat="role in getRoles() | orderBy:'name'">
-            <md-button aria-label="{{role.name}}" ng-click="bindNodeRole(role.role_id)">
-              <md-tooltip>{{role.name}}</md-tooltip>
-              <md-icon md-menu-align-target style="margin: auto 3px auto 0;">{{role.icon}}</md-icon>
+            <md-button aria-label="{{ _roles[role.id].name }}" ng-click="bindNodeRole(role.role_id)">
+              <md-tooltip>{{ _roles[role.id].description }}</md-tooltip>
+              <md-icon md-menu-align-target style="margin: auto 3px auto 0;">{{_roles[role.id].icon}}</md-icon>
+              <md-title>{{ _roles[role.id].name }}</md-title>
             </md-button>
           </md-menu-item>
           <md-menu-item ng-if='getRoles().length == 0'>

--- a/views/provider.html
+++ b/views/provider.html
@@ -123,11 +123,11 @@ provider view
     <md-card-content>
       <span ng-repeat="node in getNodes() | orderBy: 'name'">
 				<!-- Node button -->
-				<md-button class="md-fab md-primary" md-theme="status_{{node.status}}" ng-href="#/nodes/{{node.id}}">
-					<md-tooltip md-direction="bottom">
-						{{node.name}}
-					</md-tooltip>
-					<md-icon>{{ nodes.getIcon(node) }}</md-icon>
+				<md-button class="md-fab md-primary" md-theme="status_{{ api.getNodeStatus(node)}}" aria-label="{{node.name}}" ng-href="#/nodes/{{node.id}}">
+					<md-icon>{{ api.getNodeIcon(node) }}</md-icon>
+          <md-tooltip md-direction="bottom">
+            {{node.name}}
+          </md-tooltip>
 				</md-button>
 
 			</span>


### PR DESCRIPTION
Based on large system review, we were being way to aggressive with polling.
This change fixes the polling models (beyond the earlier pull that made them settable)
It also tells the UI to NOT send the large runlogs on routine updates
The runlog is retrieved ONLY when looking at the node_role page
The runlog is NOT stored in RAM to save the UX memory footprint

Also:
* cleaned up some aria labels that were causing log noise
* fixed the provider nodes rendering page