### PR TITLE
improve clairity and links between node roles and deployment roles

### DIFF
--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -143,6 +143,8 @@ node role controller
     $scope.hasAttrib = -1;
     $scope.attribs = [];
     $scope.editing = false;
+    $scope.service = false;
+    $scope.deployment_role_id = -1;
     $scope.helplink = "http://digital-rebar.readthedocs.io/en/latest/deployment/troubleshooting/roles";
     var hasCallback = false;
 
@@ -162,7 +164,15 @@ node role controller
         $location.path('/node_roles');
       else {
         $scope.node_role = $scope._node_roles[$scope.id];
-        
+        // is this a service role?
+        $scope.service = ($scope._nodes[$scope.node_role.node_id] ? $scope._nodes[$scope.node_role.node_id]["system"] : false);
+        // what is the matching deployment role?
+        for (var id in $scope._deployment_roles) {
+          if($scope._deployment_roles[id].role_id == $scope.node_role.role_id && $scope._deployment_roles[id].deployment_id == $scope.node_role.deployment_id) {
+            $scope.deployment_role_id = id;
+            break;
+          }
+        }
         if ($scope.hasAttrib == -1) {
           api('/api/v2/node_roles/' + $scope.node_role.id + "/attribs").
           success(function (obj) {

--- a/views/deployment_roles_singular.html
+++ b/views/deployment_roles_singular.html
@@ -34,7 +34,11 @@
   </md-toolbar>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
-      <span>Attributes</span>
+      <span>
+        <md-icon class='md-icon-button'>dashboard
+          <md-tooltip>Deployment Role</md-tooltip>
+        </md-icon>
+        Deployment Scope Attributes</span>
       <span flex></span>
     </div>
   </md-toolbar>
@@ -47,7 +51,11 @@
 <md-card>
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
-      <span>Node Roles</span>
+      <span>
+        <md-icon class='md-primary'>dns
+          <md-tooltip>Node Role</md-tooltip>
+        </md-icon>
+        Node Roles</span>
     </div>
   </md-toolbar>
   <md-card-content>

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -11,9 +11,10 @@
         <a ng-href='#/deployments/{{node_role.deployment_id}}'  swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_deployments[node_role.deployment_id].name}}
         </a>
-        <a ng-href='#/nodes/{{node_role.node_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-hide=service ng-href='#/nodes/{{node_role.node_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_nodes[node_role.node_id].name}}
         </a>
+        <em ng-show=service>Service Role</em>
         <md-icon class='md-primary'>
           {{_roles[node_role.role_id].icon}}
         </md-icon>
@@ -52,9 +53,20 @@
     </span>
   </div>
   <div class="md-toolbar-tools">
-    <span>Attributes</span>
+    <span flex>
+        <md-icon class='md-icon-button'>dns
+          <md-tooltip>Node Role</md-tooltip>
+        </md-icon>
+        Node Local Attributes
+    </span>
+    <span>
+      <a ng-if='deployment_role_id>0' ng-href='#/deployment_roles/{{deployment_role_id}}'>Deployment Scope Attributes
+        <md-icon class='md-icon-button'>dashboard
+          <md-tooltip>Deployment Role</md-tooltip>
+        </md-icon>
+      </a>
+    </span>
   </div>
-
   <div data-ng-include="'views/attrib_render.tmpl.html'">
   </div>
 </md-card>


### PR DESCRIPTION
before this change, it was very difficult to find the deployment role information from the service roles.
also, it was potentially confusing for users the scope of the change they were making.

this change should help to clarify the scope of attribute changes.

it also removes the link to the phantom nodes for services roles.