### PR TITLE
Role Metadata into templates based on script & ansible types

### DIFF
--- a/js/rebar.js
+++ b/js/rebar.js
@@ -678,7 +678,7 @@
       $rootScope._barclamps[id] = barclamp;
       $rootScope.$broadcast("barclamp" + id + "Done");
 
-      if (typeof barclamp.cfg_data.wizard !== 'undefined') {
+      if (barclamp.cfg_data && typeof barclamp.cfg_data.wizard !== 'undefined') {
 
         if (barclamp.cfg_data.wizard.version != 2)
           return;

--- a/js/roles.js
+++ b/js/roles.js
@@ -124,6 +124,29 @@ role controller
     });
   };
 
+  $scope.removeFile = function(index) {
+    $scope.metadata["files"].splice(index, 1);
+    api.toast('Removed Ansible File', 'file', index);
+  };
+
+  $scope.addFile = function() {
+    s = {type: 'tasks', name: 'main.yml', body: '---\n- debug: msg="Ansibile Metadata Role"'};
+    $scope.metadata["files"].push(s);
+  };
+
+  $scope.saveAnsible = function(event) {
+    api("/api/v2/barclamps/" + $scope.role.barclamp_id).
+    success(function(bc) {
+      var roles = bc.cfg_data.roles;
+      for (var r in roles) {
+        if (roles[r].name == $scope.role.name) {
+          roles[r].metadata = $scope.metadata;
+          api.saveBarclamp(bc.cfg_data);
+        };
+      };
+    });
+  };
+
   });
 
 

--- a/views/roles_ansible_play.tmpl.html
+++ b/views/roles_ansible_play.tmpl.html
@@ -1,0 +1,21 @@
+<md-toolbar class="md-table-toolbar md-default">
+  <div class="md-toolbar-tools">
+    <span flex>Ansible Metadata</span>
+    <span class='inset' ng-show="scripts.length">
+      <md-button class='md-icon-button' ng-click='addSection($index)'>
+        <md-icon>add_circle_outline</md-icon>
+        <md-tooltip>Add Section {{$index+1}}</md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-click='saveAnsible($event)'>
+        <md-icon>save</md-icon>
+        <md-tooltip>Save</md-tooltip>
+      </md-button>
+    </span>
+  </div>
+</md-toolbar>
+
+<md-card-content>
+  <pre>
+    {{ metadata | json }}
+  </pre>
+</md-card-content>

--- a/views/roles_ansible_play.tmpl.html
+++ b/views/roles_ansible_play.tmpl.html
@@ -1,11 +1,7 @@
 <md-toolbar class="md-table-toolbar md-default">
   <div class="md-toolbar-tools">
     <span flex>Ansible Metadata</span>
-    <span class='inset' ng-show="scripts.length">
-      <md-button class='md-icon-button' ng-click='addSection($index)'>
-        <md-icon>add_circle_outline</md-icon>
-        <md-tooltip>Add Section {{$index+1}}</md-tooltip>
-      </md-button>
+    <span class='inset'>
       <md-button class='md-icon-button' ng-click='saveAnsible($event)'>
         <md-icon>save</md-icon>
         <md-tooltip>Save</md-tooltip>
@@ -14,8 +10,77 @@
   </div>
 </md-toolbar>
 
+
 <md-card-content>
-  <pre>
-    {{ metadata | json }}
-  </pre>
+
+  <div ng-if='metadata["playbook_src_paths"][role.name] == "metadata"'>
+    <table layout-padding>
+      <tr>
+        <td class='label'>Playbook File</td>
+        <td><input ng-type='text' ng-model='metadata["playbook_file"]'/></td>
+      </tr>
+      <tr>
+        <td class='label'>Playbook Path</td>
+        <td><input ng-type='text' ng-model='metadata["playbook_path"]'/></td>
+      </tr>
+      <tr>
+        <td class='label'>Playbook Scope</td>
+        <td><input ng-type='text' ng-model='metadata["playbook_scope"]'/></td>
+      </tr>
+      <tr>
+        <td class='label'>Role Map</td>
+        <td>
+          <span ng-repeat='(key, value) in metadata["role_role_map"] track by key'>
+            <input ng-type='text' ng-model='key'/>
+            <input ng-type='text' ng-model='value'/>
+          </span>
+        </td>
+      </tr>
+      <tr>
+        <td class='label'>Playbook Source Paths</td>
+        <td>
+          <span ng-repeat='(key, value) in metadata["playbook_src_paths"] track by key'>
+            <input ng-type='text' ng-model='key'/>
+            <input ng-type='text' ng-model='value'/>
+          </span>
+        </td>
+      </tr>
+    </table>
+
+    <table layout-padding width='100%'>
+      <tr>
+        <th width='15%'>File</th>
+        <th>File Body</th>
+        <td>
+          <md-button class='md-icon-button' ng-click='addFile($index)'>
+            <md-icon>add_circle_outline</md-icon>
+            <md-tooltip>Add File {{$index+1}}</md-tooltip>
+          </md-button>
+        </td>
+      </tr >
+      <tr ng-repeat='file in metadata["files"]'>
+        <td>
+          Path: <input ng-type='text' ng-model='file["type"]'/>
+          Name: <input ng-type='text' ng-model='file["name"]'/>
+        </td>
+        <td><textarea ng-model='file["body"]' style='width: 100%; font-family: monospace; min-height: 100px;'></textarea></td>
+        <td>
+          <md-button class='md-icon-button' ng-click='removeFile($index)'>
+            <md-icon>clear</md-icon>
+            <md-tooltip>Remove File {{$index+1}}</md-tooltip>
+          </md-button>
+        </td>
+
+      </tr>
+    </table>
+    <hr/>
+    <span flex>Ansible Metadata Preview</span>
+    <pre> {{ metadata | json }} </pre>
+  </div>
+
+  <div ng-if='metadata["playbook_src_paths"][role.name] != "metadata"'>
+    <span flex>Ansible Metadata Editor</span>
+    <textarea json-text ng-model='metadata' style='width: 100%; font-family: monospace; min-height: 200px;'></textarea>
+  </div>
+
 </md-card-content>

--- a/views/roles_script.tmpl.html
+++ b/views/roles_script.tmpl.html
@@ -1,0 +1,29 @@
+<md-toolbar class="md-table-toolbar md-default">
+  <div class="md-toolbar-tools">
+    <span flex>Script Metadata</span>
+    <span class='inset' ng-show="scripts.length">
+      <md-button class='md-icon-button' ng-click='addSection($index)'>
+        <md-icon>add_circle_outline</md-icon>
+        <md-tooltip>Add Section {{$index+1}}</md-tooltip>
+      </md-button>
+      <md-button class='md-icon-button' ng-click='saveScripts($event)'>
+        <md-icon>save</md-icon>
+        <md-tooltip>Save</md-tooltip>
+      </md-button>
+    </span>
+  </div>
+</md-toolbar>
+
+<md-card-content>
+  <div ng-repeat="(key, value) in scripts track by key">
+    <md-dialog-content layout='row' id="section_{{key}}" ng-show="scripts[key]">
+      <span>Section {{ $index+1 }}
+        <md-button class='md-icon-button' ng-click='removeSection($index)'>
+          <md-icon>clear</md-icon>
+          <md-tooltip>Remove Section {{$index+1}}</md-tooltip>
+        </md-button>
+      </span>
+      <textarea ng-model='scripts[key]' style='width: 100%; font-family: monospace; min-height: 100px;'></textarea>
+    </md-dialog-content>
+  </div>
+</md-card-content>

--- a/views/roles_singular.html
+++ b/views/roles_singular.html
@@ -71,6 +71,11 @@
 
 <!-- Show Meta Data -->
 <md-card>
+  <md-toolbar class="md-table-toolbar md-default">
+    <div class="md-toolbar-tools">
+      <span flex>Related Roles</span>
+    </div>
+  </md-toolbar>
   <md-card-content>
     <table layout-padding flex width="100%">
       <thead>
@@ -116,38 +121,25 @@
 </md-card>
 
 <!-- Show Meta Data -->
-<md-card>
-  <md-toolbar class="md-table-toolbar md-default">
-    <div class="md-toolbar-tools">
-      <span flex>Metadata</span>
-      <span class='inset' ng-show="scripts.length">
-        <md-button class='md-icon-button' ng-click='addSection($index)'>
-          <md-icon>add_circle_outline</md-icon>
-          <md-tooltip>Add Section {{$index+1}}</md-tooltip>
-        </md-button>
-        <md-button class='md-icon-button' ng-click='saveScripts($event)'>
-          <md-icon>save</md-icon>
-          <md-tooltip>Save</md-tooltip>
-        </md-button>
-      </span>
+<md-card ng-switch="role.jig_name">
+  <div ng-switch-when="script">
+    <div data-ng-include="'views/roles_script.tmpl.html'">
     </div>
-  </md-toolbar>
-  <md-card-content ng-show="scripts.length">
-    <div ng-repeat="(key, value) in scripts track by key">
-      <md-dialog-content layout='row' id="section_{{key}}" ng-show="scripts[key]">
-        <span>Section {{ $index+1 }}
-          <md-button class='md-icon-button' ng-click='removeSection($index)'>
-            <md-icon>clear</md-icon>
-            <md-tooltip>Remove Section {{$index+1}}</md-tooltip>
-          </md-button>
-        </span>
-        <textarea ng-model='scripts[key]' style='width: 100%; font-family: monospace; min-height: 100px;'></textarea>
-      </md-dialog-content>
+  </div>
+  <div ng-switch-when="ansible-playbook">
+    <div data-ng-include="'views/roles_ansible_play.tmpl.html'">
     </div>
-  </md-card-content>
-  <md-card-content ng-hide="scripts.length">
-    <pre>
-      {{ metadata | json }}
-    </pre>
-  </md-card-content>
+  </div>
+  <div ng-switch-default>
+    <md-toolbar class="md-table-toolbar md-default">
+      <div class="md-toolbar-tools">
+        <span flex>Metadata</span>
+      </div>
+    </md-toolbar>
+    <md-card-content>
+      <pre>
+        {{ metadata | json }}
+      </pre>
+    </md-card-content>
+  </div>
 </md-card>


### PR DESCRIPTION
This is the first step to allowing different jig to render metadata helpers like we did for Script.