### PR TITLE
Syntax improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,7 +32,8 @@
   -moz-osx-font-smoothing: grayscale;
 
   /* Support for IE. */
-  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
+          font-feature-settings: 'liga';
 }
 
 md-sidenav {
@@ -59,8 +60,8 @@ md-sidenav ng-md-icon {
 }
 
 table td.label {
-  text-align: right;
   font-weight: bold;
+  text-align: right;
 }
 
 .login-autocomplete md-input-container {
@@ -82,25 +83,27 @@ table td.label {
 
 th.angled {
   height: 140px;
-  whitespace: nowrap;
+  white-space: nowrap
 }
 
 th.angled div {
+  height: 24px;
   position: relative;
-  transform: translate(5px, 60px) rotateZ(-45deg);
+  -ms-transform: translate(5px, 60px) rotateZ(-45deg);
+  -webkit-transform: translate(5px, 60px) rotateZ(-45deg);
+          transform: translate(5px, 60px) rotateZ(-45deg);
   white-space: nowrap;
   width: 24px;
-  height: 24px;
 }
 
 th.angled div a {
-  white-space: nowrap;
   overflow: visible;
+  white-space: nowrap;
 }
 
 .status {
-  padding: 4px;
   border-radius: 50%;
+  padding: 4px;
 }
 
 
@@ -110,9 +113,9 @@ json-text {
 
 /* style for toolbar when a table has selected items*/
 md-toolbar.md-table-toolbar.alternate .md-toolbar-tools {
+  background-color: #e3f2fd;
   color: #1e88e5;
   font-size: 16px;
-  background-color: #e3f2fd;
 }
 
 md-toolbar.md-tall.md-hue-2 {
@@ -120,6 +123,9 @@ md-toolbar.md-tall.md-hue-2 {
       rgba(16, 47, 100, 0.8), 
       rgba(16, 47, 100, 0.8)
     ), url('logo.jpg') cover;*/
+    background-image: -webkit-linear-gradient(
+      rgba(16, 47, 100, 0.8), 
+      rgba(8, 24, 50, 1) 90%), url('logo.jpg');
     background-image: linear-gradient(
       rgba(16, 47, 100, 0.8), 
       rgba(8, 24, 50, 1) 90%), url('logo.jpg');
@@ -130,13 +136,13 @@ md-toolbar.md-tall.md-hue-2 {
 }
 
 a {
-  text-decoration: none;
   color: #1565C0;
+  text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
   color: #1565C0;
+  text-decoration: underline;
 }
 
 a:visited:not(.md-button) {
@@ -144,9 +150,9 @@ a:visited:not(.md-button) {
 }
 
 div.centered h1 {
-  text-align: center;
-  font-weight: normal;
   font-family: 'Roboto', Helvetica, sans-serif;
+  font-weight: normal;
+  text-align: center;
 }
 
 div md-progress-circular {
@@ -157,6 +163,7 @@ div md-progress-circular {
 .ng-view.ng-cloak,
 .ng-view.ng-binding {
     opacity: 0;
+    -webkit-transition: opacity 800ms ease-in-out;
     transition: opacity 800ms ease-in-out;
 }
 .ng-view.ng-binding {
@@ -197,37 +204,80 @@ div md-progress-circular {
 }
 
 .pulse {
-  animation: pulse 2s infinite linear;
+  -webkit-animation: pulse 2s infinite linear;
+          animation: pulse 2s infinite linear;
+}
+
+@-webkit-keyframes pulse {
+  0% {
+    -webkit-transform: rotateZ(0deg);
+            transform: rotateZ(0deg);
+  }
+  30% {
+    -webkit-transform: rotateZ(180deg);
+            transform: rotateZ(180deg);
+  }
+  60% {
+    -webkit-transform: rotateZ(360deg);
+            transform: rotateZ(360deg);
+  }
+  80% {
+    -webkit-transform: rotateZ(540deg);
+            transform: rotateZ(540deg);
+  }
+  100% {
+    -webkit-transform: rotateZ(720deg);
+            transform: rotateZ(720deg);
+  }
 }
 
 @keyframes pulse {
   0% {
-    transform: rotateZ(0deg);
+    -webkit-transform: rotateZ(0deg);
+            transform: rotateZ(0deg);
   }
   30% {
-    transform: rotateZ(180deg);
+    -webkit-transform: rotateZ(180deg);
+            transform: rotateZ(180deg);
   }
   60% {
-    transform: rotateZ(360deg);
+    -webkit-transform: rotateZ(360deg);
+            transform: rotateZ(360deg);
   }
   80% {
-    transform: rotateZ(540deg);
+    -webkit-transform: rotateZ(540deg);
+            transform: rotateZ(540deg);
   }
   100% {
-    transform: rotateZ(720deg);
+    -webkit-transform: rotateZ(720deg);
+            transform: rotateZ(720deg);
   }
 }
 
 .rotate {
-  animation: rotate 0.5s infinite ease;
+  -webkit-animation: rotate 0.5s infinite ease;
+          animation: rotate 0.5s infinite ease;
+}
+
+@-webkit-keyframes rotate {
+  0% {
+    -webkit-transform: rotateZ(0deg);
+            transform: rotateZ(0deg);
+  }
+  100% {
+    -webkit-transform: rotateZ(180deg);
+            transform: rotateZ(180deg);
+  }
 }
 
 @keyframes rotate {
   0% {
-    transform: rotateZ(0deg);
+    -webkit-transform: rotateZ(0deg);
+            transform: rotateZ(0deg);
   }
   100% {
-    transform: rotateZ(180deg);
+    -webkit-transform: rotateZ(180deg);
+            transform: rotateZ(180deg);
   }
 }
 
@@ -268,8 +318,12 @@ table.md-table td.md-cell md-icon {
   height: 48px;
   cursor: pointer;
   position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   width: auto;
 }
 
@@ -306,10 +360,18 @@ table.no-border, table.no-border tr, table.no-border tr td{
   width: 20%;
   padding: 4px;
   text-align: center;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
-  justify-content: center;
-  transform: translateX(0);
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-transform: translateX(0);
+          transform: translateX(0);
   outline: none;
 }
 
@@ -324,6 +386,7 @@ table.no-border, table.no-border tr, table.no-border tr td{
   border: 2px solid lightgrey;
   color: lightgrey;
   background-color: rgba(21,101,192, 0);
+  -webkit-transition: border-color 0.5s, background-color 0.5s, color 0.5s;
   transition: border-color 0.5s, background-color 0.5s, color 0.5s;
 }
 
@@ -335,6 +398,7 @@ table.no-border, table.no-border tr, table.no-border tr td{
   content: '';
   width: calc(50% - 4px - 16px);
   border-bottom: 2px solid lightgrey;
+  -webkit-transition: border-color 0.5s;
   transition: border-color 0.5s;
 }
 
@@ -347,6 +411,7 @@ table.no-border, table.no-border tr, table.no-border tr td{
   content: '';
   width: calc(50% - 4px - 16px);
   border-bottom: 2px solid lightgrey;
+  -webkit-transition: border-color 0.5s;
   transition: border-color 0.5s;
 }
 
@@ -400,9 +465,16 @@ table.no-border, table.no-border tr, table.no-border tr td{
 
 .wizard-content .icon-container {
   text-align: center;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
-  justify-content: center;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 16px;
 }
 
@@ -419,7 +491,8 @@ table.no-border, table.no-border tr, table.no-border tr td{
 
 .graph-card {
   overflow: hidden;
-  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+          transform: translateZ(0);
 }
 
 .graph-overlay {

--- a/index.html
+++ b/index.html
@@ -1,7 +1,11 @@
 <!doctype html>
-<html ng-app='app'>
+<html ng-app="app" lang="en-us">
 
   <head>
+
+    <meta charset="utf-8" />
+    <meta name="author" content="RackN" />
+    <meta description="RackN Interace for Digital Rebar">
 
     <!-- Material CSS-->
     <link rel="stylesheet" type="text/css" href="bower_components/angular-material/angular-material.css" />
@@ -9,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="css/font.css" />
     <link rel="stylesheet" type="text/css" href="css/style.css" />
 
-    <link rel="SHORTCUT ICON" href="/ux/favicon.ico" />
+    <link rel="SHORTCUT ICON" href="favicon.ico" />
 
     <title>
       Digital Rebar [{{host}}]
@@ -85,31 +89,31 @@
     <script src="js/bios_updates.js"></script>
 
     <!-- Side Nav -->
-    <md-sidenav layout="column" class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$mdMedia('gt-md')" ng-show='isAuth()'>
+    <md-sidenav layout="column" class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$mdMedia('gt-md')" ng-show="isAuth()">
 
       <!-- Tall toolbar on top of the sidebar -->
-      <md-toolbar class='md-tall md-hue-2'>
+      <md-toolbar class="md-tall md-hue-2">
         <span flex></span>
         <div layout="column" class="md-toolbar-tools-bottom inset">
-          <div><a ng-href='#/users/{{user.id}}' style='color: #f5f5f5;'>
+          <div><a ng-href="#/users/{{user.id}}" style="color: #f5f5f5;">
           <md-icon>person</md-icon> {{user.username}}</a></div>
-          <div><a target="_blank" ng-href='{{host}}' style='color: #f5f5f5;'>{{host}}</a></div>
+          <div><a target="_blank" ng-href="{{host}}" style="color: #f5f5f5;">{{host}}</a></div>
         </div>
       </md-toolbar>
 
-      <md-list style='overflow-y: auto;'>
+      <md-list style="overflow-y: auto;">
 
         <!-- Default menu -->
-        <div ng-repeat="item in menu" ng-if='!item.hide()'>
+        <div ng-repeat="item in menu" ng-if="!item.hide()">
           <md-list-item ng-click="item.expand ? item.toggleExpand() : setPath(item.path)">
             <md-icon>{{item.icon}}</md-icon>
             <p>{{item.title}}</p>
-            <md-icon ng-if='item.expand'>{{item.expanded()?"expand_less":"expand_more"}}</md-icon>
+            <md-icon ng-if="item.expand">{{item.expanded()?"expand_less":"expand_more"}}</md-icon>
           </md-list-item>
 
-          <div ng-slide-down='item.expanded()' duration='0.5' lazy-render ng-if='item.expand'>
-            <md-list-item ng-repeat='child in item.items' ng-click='setPath(child.path)'>
-              <md-icon style='padding-left: 1em;'>{{child.icon}}</md-icon>
+          <div ng-slide-down="item.expanded()" duration="0.5" lazy-render ng-if="item.expand">
+            <md-list-item ng-repeat="child in item.items" ng-click="setPath(child.path)">
+              <md-icon style="padding-left: 1em;">{{child.icon}}</md-icon>
               <p>{{child.title}}</p>
             </md-list-item>
           </div>
@@ -118,16 +122,16 @@
         <md-divider></md-divider>
 
         <!-- Management menu -->
-        <div ng-repeat="item in managementMenu" ng-if='!item.hide()'>
+        <div ng-repeat="item in managementMenu" ng-if="!item.hide()">
           <md-list-item ng-click="item.expand ? item.toggleExpand() : setPath(item.path)">
             <md-icon>{{item.icon}}</md-icon>
             <p>{{item.title}}</p>
-            <md-icon ng-if='item.expand'>{{item.expanded()?"expand_less":"expand_more"}}</md-icon>
+            <md-icon ng-if="item.expand">{{item.expanded()?"expand_less":"expand_more"}}</md-icon>
           </md-list-item>
 
-          <div ng-slide-down='item.expanded()' duration='0.5' lazy-render ng-if='item.expand'>
-            <md-list-item ng-repeat='child in item.items' ng-click='setPath(child.path)'>
-              <md-icon style='padding-left: 1em;'>{{child.icon}}</md-icon>
+          <div ng-slide-down="item.expanded()" duration="0.5" lazy-render ng-if="item.expand">
+            <md-list-item ng-repeat="child in item.items" ng-click="setPath(child.path)">
+              <md-icon style="padding-left: 1em;">{{child.icon}}</md-icon>
               <p>{{child.title}}</p>
             </md-list-item>
           </div>
@@ -143,18 +147,18 @@
 
     </md-sidenav>
 
-    <md-content layout="column" layout-fill class='bg'>
+    <md-content layout="column" layout-fill class="bg">
       <!-- Header -->
-      <md-toolbar layout="column" class='md-whiteframe-z1' ng-show='isAuth()' id='toolbar'>
-        <div class='md-toolbar-tools'>
+      <md-toolbar layout="column" class="md-whiteframe-z1" ng-show="isAuth()" id="toolbar">
+        <div class="md-toolbar-tools">
           <md-button class="md-icon-button" ng-click="toggleSideNav('left')" hide-gt-md aria-label="Menu">
             <md-icon>menu</md-icon>
           </md-button>
 
           <h2>{{title}}</h2>
           <span flex></span>
-          <md-menu md-position-mode="target-right target" style='padding: 0;' ng-if='!provider'>
-            <h2 ng-click='$mdOpenMenu($event)'>
+          <md-menu md-position-mode="target-right target" style="padding: 0;" ng-if="!provider">
+            <h2 ng-click="$mdOpenMenu($event)">
               <md-icon aria-label="Tenant">group</md-icon> {{_tenants[user.current_tenant_id].name}}
               <md-tooltip>
                 Change Current Tenant
@@ -170,19 +174,19 @@
               </md-menu-item>
             </md-menu-content>
           </md-menu>
-          <md-button class="md-icon-button" ng-click='api.reload()' ng-model-options="{ debounce: 500 }">
+          <md-button class="md-icon-button" ng-click="api.reload()" ng-model-options="{ debounce: 500 }">
             <md-tooltip>
               Refresh Data
             </md-tooltip>
             <md-icon ng-class="{pulse: api.reloading}">refresh</md-icon>
           </md-button>
-          <md-button class="md-icon-button" ng-href='#/annealer'>
+          <md-button class="md-icon-button" ng-href="#/annealer">
             <md-tooltip>
               Annealer (updates every {{ _pollRate }} seconds)
             </md-tooltip>
             <md-icon>track_changes</md-icon>
           </md-button>
-          <md-button target="_new" class="md-icon-button" ng-href='http://digital-rebar.readthedocs.io/en/latest/'>
+          <md-button target="_new" class="md-icon-button" ng-href="http://digital-rebar.readthedocs.io/en/latest/">
             <md-tooltip>
               Documentation
             </md-tooltip>
@@ -193,7 +197,7 @@
       </md-toolbar>
 
       <!-- Content -->
-      <div ng-view ng-cloak style='overflow: auto;' scroll-position='scroll'>
+      <div ng-view ng-cloak style="overflow: auto;" scroll-position="scroll">
       </div>
     </md-content>
 

--- a/views/annealer.html
+++ b/views/annealer.html
@@ -1,9 +1,9 @@
 <div class="md-toolbar-tools">
 	<span flex> </span>
-	<span class='pull-right'>
-		Background Poll Rate: <input aria-label='poll rate' ng-model='_pollRate' min=5 max=300 type='number' ng-change='api.pollRate(_pollRate, true)' /> seconds
+	<span class="pull-right">
+		Background Poll Rate: <input aria-label="poll rate" ng-model="_pollRate" min="5" max="300" type="number" ng-change="api.pollRate(_pollRate, true)" /> seconds
 	</span>
-	<md-button class='md-icon-button' ng-click='api.getActive()'>
+	<md-button class="md-icon-button" ng-click="api.getActive()">
 	  <md-icon>autorenew</md-icon>
 	  <md-tooltip>Refresh Annealer Queue</md-tooltip>
 	</md-button>
@@ -16,7 +16,7 @@
 				{{status}}
 			</h2>
       <span flex></span>
-      <md-button class='md-icon-button' ng-if="status=='error'" ng-click='retryAll()'>
+      <md-button class="md-icon-button" ng-if="status=='error'" ng-click="retryAll()">
         <md-icon>redo</md-icon>
         <md-tooltip>Retry All</md-tooltip>
       </md-button>
@@ -30,8 +30,8 @@
 				md-theme="status_{{role.status}}"
 				ng-href="#/node_roles/{{role.id}}"
 				ng-class="{'md-accent': selected==role.node_id}"
-				ng-mouseenter='setNode(role.node_id)'
-				ng-mouseleave='setNode(-1)'
+				ng-mouseenter="setNode(role.node_id)"
+				ng-mouseleave="setNode(-1)"
 				>
 				<md-tooltip md-direction="bottom">
 					{{_roles[role.role_id].name}}
@@ -39,8 +39,8 @@
 				<md-icon ng-class="{pulse: status == 'process'}">{{_roles[role.role_id].icon}}</md-icon>
 			</md-button>
 		</span>
-    <div ng-if='getNodeRoles(status).length == 0'>
+    <div ng-if="getNodeRoles(status).length == 0">
       None
-      <div>
+    </div>
   </md-card-content>
 </md-card>

--- a/views/api_helper.html
+++ b/views/api_helper.html
@@ -2,33 +2,33 @@
   <section>
     <table>
       <tr>
-        <td style='font-weight: bold; text-align: right; width: 100px;'>Route</td>
-        <td layout='row'>
-          <select ng-model='method' class='table-input'>
-            <option value='get'>GET</option>
-            <option value='head'>HEAD</option>
-            <option value='post'>POST</option>
-            <option value='put'>PUT</option>
-            <option value='delete'>DELETE</option>
-            <option value='trace'>TRACE</option>
-            <option value='options'>OPTIONS</option>
-            <option value='connect'>CONNECT</option>
-            <option value='path'>PATH</option>
-            <option value='patch'>PATCH</option>
+        <td style="font-weight: bold; text-align: right; width: 100px;">Route</td>
+        <td layout="row">
+          <select ng-model="method" class="table-input">
+            <option value="get">GET</option>
+            <option value="head">HEAD</option>
+            <option value="post">POST</option>
+            <option value="put">PUT</option>
+            <option value="delete">DELETE</option>
+            <option value="trace">TRACE</option>
+            <option value="options">OPTIONS</option>
+            <option value="connect">CONNECT</option>
+            <option value="path">PATH</option>
+            <option value="patch">PATCH</option>
           </select>
-          <input type='text' class='table-input' ng-model='route' placeholder="/api/v2/" />
+          <input type="text" class="table-input" ng-model="route" placeholder="/api/v2/" />
         </td>
       </tr>
       <tr>
-        <td valign='top' style='font-weight: bold; text-align: right;'>Payload</td>
+        <td valign="top" style="font-weight: bold; text-align: right;">Payload</td>
         <td>
-          <textarea ng-model='payload' style='width: 600px; height: 100px; font-family: monospace' ng-class="{'error': !parse(payload)}"></textarea>
+          <textarea ng-model="payload" style="width: 600px; height: 100px; font-family: monospace" ng-class="{'error': !parse(payload)}"></textarea>
         </td>
       </tr>
       <tr>
         <td></td>
-        <td layout='column'>
-          <md-button class='md-raised md-primary' ng-click='testApi()'> 
+        <td layout="column">
+          <md-button class="md-raised md-primary" ng-click="testApi()"> 
             Run API
           </md-button>
         </td>
@@ -38,15 +38,15 @@
   <section>
     <table>
       <tr>
-        <td valign='top' style='font-weight: bold; text-align: right; width: 100px;'>Output</td>
+        <td valign="top" style="font-weight: bold; text-align: right; width: 100px;">Output</td>
         <td>
-          <textarea ng-model='output' ng-class="class" readonly style='width: 600px; height: 300px; font-family: monospace'></textarea>
+          <textarea ng-model="output" ng-class="class" readonly style="width: 600px; height: 300px; font-family: monospace"></textarea>
         </td>
       </tr>
       <tr>
         <td></td>
-        <td layout='column'>
-          <md-button ng-click="clearOutput()" class='md-raised md-primary'>Clear</md-button>
+        <td layout="column">
+          <md-button ng-click="clearOutput()" class="md-raised md-primary">Clear</md-button>
         </td>
       </tr>
     </table>

--- a/views/attrib_render.tmpl.html
+++ b/views/attrib_render.tmpl.html
@@ -11,40 +11,40 @@
     <table layout-padding flex>
       <tbody>
         <tr ng-repeat="attrib in attribs | orderBy:'name'">
-          <td class='label' valign="top">
-            <a ng-click='alert(attrib.id)' title='{{attrib.description}}'>
+          <td class="label" valign="top">
+            <a ng-click="alert(attrib.id)" title="{{attrib.description}}">
               {{attrib.name}}
             </a>
           </td>
-          <td ng-switch='attrib.schema.type'>
+          <td ng-switch="attrib.schema.type">
             <div data-ng-switch-when="map">
               <div ng-click="visible=!visible">
                 <div>
-                  <span style='font-family: monospace;'>{{visible ? "Collapse &uarr;" : attrib.preview + " &darr;"}}</span>
+                  <span style="font-family: monospace;">{{visible ? "Collapse &uarr;" : attrib.preview + " &darr;"}}</span>
                 </div>
               </div>
-              <div ng-show='visible || editing'>
-                <textarea json-text class='table-input' ng-readonly="!attrib.writable || attrib.writable && !editing" style='height: 300px; font-size: inherit; font-family: monospace;' ng-model='attrib.value'>
+              <div ng-show="visible || editing">
+                <textarea json-text class="table-input" ng-readonly="!attrib.writable || attrib.writable && !editing" style="height: 300px; font-size: inherit; font-family: monospace;" ng-model="attrib.value">
                 </textarea>
               </div>
             </div>
             <div data-ng-switch-when="seq">
               <div ng-click="visible=!visible">
                 <div>
-                  <span style='font-family: monospace;'>{{visible ? "Collapse &uarr;" : attrib.preview + " &darr;"}}</span>
+                  <span style="font-family: monospace;">{{visible ? "Collapse &uarr;" : attrib.preview + " &darr;"}}</span>
                 </div>
               </div>
-              <div ng-show='visible || editing'>
-                <textarea json-text class='table-input' ng-readonly="!attrib.writable || attrib.writable && !editing" style='height: 300px; font-size: inherit; font-family: monospace;' ng-model='attrib.value'>
+              <div ng-show="visible || editing">
+                <textarea json-text class="table-input" ng-readonly="!attrib.writable || attrib.writable && !editing" style="height: 300px; font-size: inherit; font-family: monospace;" ng-model="attrib.value">
                 </textarea>
               </div>
             </div>
             <div data-ng-switch-default>
-              <input type='text' class='table-input' ng-readonly="!attrib.writable || attrib.writable && !editing" style='font-family: monospace;' ng-model='attrib.value' />
+              <input type="text" class="table-input" ng-readonly="!attrib.writable || attrib.writable && !editing" style="font-family: monospace;" ng-model="attrib.value" />
             </div>
           </td>
-          <td ng-if='attrib.writable'>
-            <md-button class='md-icon-button' ng-click='showEditAttribDialog($event, attrib, target)'>
+          <td ng-if="attrib.writable">
+            <md-button class="md-icon-button" ng-click="showEditAttribDialog($event, attrib, target)">
               <md-icon>
                 edit
               </md-icon>

--- a/views/attribs.html
+++ b/views/attribs.html
@@ -13,14 +13,14 @@
       <table md-table>
         <thead md-head md-order="order">
           <tr md-row>
-            <th md-column md-order-by='name'>Name</th>
+            <th md-column md-order-by="name">Name</th>
             <th md-column>Description</th>
-            <th md-column md-order-by='map'>Map</th>
+            <th md-column md-order-by="map">Map</th>
           </tr>
         </thead>
         <tbody md-body>
           <tr md-row ng-repeat="attrib in attribs | orderBy: order">
-            <td md-cell>{{attrib.name}}</a></td>
+            <td md-cell>{{attrib.name}}</td>
             <td md-cell>{{attrib.description}}</td>
             <td md-cell>{{attrib.map}}</td>
           </tr>

--- a/views/barclamps.html
+++ b/views/barclamps.html
@@ -9,8 +9,8 @@
     <table md-table>
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='id'>Barclamp</th>
-          <th md-column md-order-by='barclamp_id'>Parent</th>
+          <th md-column md-order-by="id">Barclamp</th>
+          <th md-column md-order-by="barclamp_id">Parent</th>
           <th md-column>Description</th>
           <th md-column>Source</th>
           <th md-column>Roles</th>
@@ -19,12 +19,12 @@
       <tbody md-body>
         <tr md-row ng-repeat="barclamp in getBarclamps() | orderBy: myOrder">
           <td md-cell>
-            <a ng-href='#/barclamps/{{barclamp.id}}'>
+            <a ng-href="#/barclamps/{{barclamp.id}}">
               {{barclamp.name}}
             </a>
           </td>
           <td md-cell>
-            <a ng-href='#/barclamps/{{barclamp.barclamp_id}}'>
+            <a ng-href="#/barclamps/{{barclamp.barclamp_id}}">
               {{_barclamps[barclamp.barclamp_id].name}}
             </a>
           </td>
@@ -32,18 +32,18 @@
             {{barclamp.description}}
           </td>
           <td md-cell>
-            <md-icon ng-show='barclamp.source_path=="API_uploaded" || barclamp.source_path==""' title="User Uploaded">
+            <md-icon ng-show="barclamp.source_path=='API_uploaded' || barclamp.source_path==''" title="User Uploaded">
               face
             </md-icon>
-            <md-icon ng-show='barclamp.source_path=="/opt/digitalrebar/core"' title="{{barclamp.source_path}}">
+            <md-icon ng-show="barclamp.source_path=='/opt/digitalrebar/core'" title="{{barclamp.source_path}}">
               attachment
             </md-icon>
-            <md-icon ng-hide='barclamp.source_path=="/opt/digitalrebar/core" || barclamp.source_path=="API_uploaded"' title="{{barclamp.source_path}}">
+            <md-icon ng-hide="barclamp.source_path=='/opt/digitalrebar/core' || barclamp.source_path=='API_uploaded'" title="{{barclamp.source_path}}">
               extension
             </md-icon>
           </td>
           <td md-cell>
-            <md-button ng-href='#/roles/{{role.id}}' class='md-fab md-primary md-mini' ng-repeat="role in getRoles(barclamp.cfg_data.roles)">
+            <md-button ng-href="#/roles/{{role.id}}" class="md-fab md-primary md-mini" ng-repeat="role in getRoles(barclamp.cfg_data.roles)">
               <md-icon>
                 {{role.icon}}
               </md-icon>
@@ -59,12 +59,12 @@
 </md-card>
 <!-- Floating action button at the bottom right of the screen -->
 <div layout="horizontal" layout-align="center end">
-  <input type="file" id="file" name="file" ng-model="selectedFile" onchange='angular.element(this).scope().upload()' style='opacity: 0;'/>
-  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click='selectFile()' style="transform: translateX(-150%);">
+  <input type="file" id="file" name="file" ng-model="selectedFile" onchange="angular.element(this).scope().upload()" style="opacity: 0;"/>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="selectFile()" style="transform: translateX(-150%);">
     <md-icon>file_upload</md-icon>
     <md-tooltip>Upload</md-tooltip>
   </md-button>
-  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click='barclamps.showUpdateBarclampDialog()'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="barclamps.showUpdateBarclampDialog()">
     <md-icon>add</md-icon>
     <md-tooltip>Add Workload Roles</md-tooltip>
   </md-button>

--- a/views/barclamps_singular.html
+++ b/views/barclamps_singular.html
@@ -4,9 +4,9 @@
       <span flex>
         {{barclamp.name}} ({{barclamp.description}})
       </span>
-      <span ng-if='barclamp.id != barclamp.barclamp_id'>
+      <span ng-if="barclamp.id != barclamp.barclamp_id">
         Parent: 
-          <a ng-href='#/barclamps/{{barclamp.barclamp_id}}' swap-md-pain-fg="foreground">
+          <a ng-href="#/barclamps/{{barclamp.barclamp_id}}" swap-md-pain-fg="foreground">
           {{ _barclamps[barclamp.barclamp_id].name }}
         </a>
       </span>
@@ -15,13 +15,13 @@
   <md-card-content>
     <apan flex="5" />
     <span>
-      <md-icon ng-show='barclamp.source_path=="API_uploaded" || barclamp.source_path==""' title="User Uploaded">
+      <md-icon ng-show="barclamp.source_path=='API_uploaded' || barclamp.source_path==''" title="User Uploaded">
         face
       </md-icon>
-      <md-icon ng-show='barclamp.source_path=="/opt/digitalrebar/core"' title="source path">
+      <md-icon ng-show="barclamp.source_path=='/opt/digitalrebar/core'" title="source path">
         attachment
       </md-icon>
-      <md-icon ng-hide='barclamp.source_path=="/opt/digitalrebar/core" || barclamp.source_path=="API_uploaded"' title="source path">
+      <md-icon ng-hide="barclamp.source_path=='/opt/digitalrebar/core' || barclamp.source_path=='API_uploaded'" title="source path">
         extension
       </md-icon>
       {{ barclamp.source_path }}
@@ -37,7 +37,7 @@
     </div>
   </md-toolbar>
   <md-card-content>
-    <md-button ng-href='#/roles/{{role.id}}' class='md-fab md-primary' ng-repeat="role in getRoles(barclamp.cfg_data.roles)">
+    <md-button ng-href="#/roles/{{role.id}}" class="md-fab md-primary" ng-repeat="role in getRoles(barclamp.cfg_data.roles)">
       <md-icon>
         {{role.icon}}
       </md-icon>
@@ -45,7 +45,7 @@
         {{role.name}}
       </md-tooltip>
     </md-button>
-  <md-card-content>
+  </md-card-content>
 </md-card>
 
 <!-- Show node roles -->
@@ -53,19 +53,19 @@
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
       <span flex>Source</span>
-      <input type="file" id="file" name="file" ng-model="selectedFile" onchange='angular.element(this).scope().upload()' style='opacity: 0;'/>
-      <md-button class='md-icon-button' ng-click='selectFile()'>
+      <input type="file" id="file" name="file" ng-model="selectedFile" onchange="angular.element(this).scope().upload()" style="opacity: 0;"/>
+      <md-button class="md-icon-button" ng-click="selectFile()">
         <md-icon>file_upload</md-icon>
         <md-tooltip>Upload</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='barclamps.showUpdateBarclampDialog()'>
+      <md-button class="md-icon-button" ng-click="barclamps.showUpdateBarclampDialog()">
         <md-icon>edit</md-icon>
         <md-tooltip>Edit</md-tooltip>
       </md-button>
     </div>
   </md-toolbar>
   <md-card-content>
-    <pre style='overflow-x: auto;'>
+    <pre style="overflow-x: auto;">
       {{ barclamp.cfg_data | json }}
     </pre>
   </md-card-content>

--- a/views/bios_settings.html
+++ b/views/bios_settings.html
@@ -2,28 +2,28 @@
 bios settings view
 -->
 <div>
-  <md-card ng-repeat='(ind , setting) in settings' flex='100'>
+  <md-card ng-repeat="(ind , setting) in settings" flex="100">
 
-    <div ng-show='settings[ind]'>
+    <div ng-show="settings[ind]">
       <!-- Top bar for each class of settings -->
-      <md-toolbar flex layout='column' md-theme="status_{{(setting.parent ? 'proposed' : 'ready')}}" ng-click="biossettings.toggleExpand(ind)" md-ink-ripple>
-        <section layout='row'>
+      <md-toolbar flex layout="column" md-theme="status_{{(setting.parent ? 'proposed' : 'ready')}}" ng-click="biossettings.toggleExpand(ind)" md-ink-ripple>
+        <section layout="row">
           <div class="md-toolbar-tools">
             <h2 flex>
-              <a ng-href='#/roles/{{setting.role_id}}'>{{setting.role}}</a>:
-              <span ng-if='setting.parent'>{{setting.parent}} +</span>
+              <a ng-href="#/roles/{{setting.role_id}}">{{setting.role}}</a>:
+              <span ng-if="setting.parent">{{setting.parent}} +</span>
               {{setting.name}}
             </h2>
           </div>
-          <span class='inset'>
-            <md-button class='md-icon-button' ng-show="dirty" ng-click='saveSetting($event, ind)'>
+          <span class="inset">
+            <md-button class="md-icon-button" ng-show="dirty" ng-click="saveSetting($event, ind)">
               <md-icon>save</md-icon>
               <md-tooltip>Save</md-tooltip>
             </md-button>
           </span>
 
           <!-- Expand button -->
-          <span class='inset'>
+          <span class="inset">
             <md-button class="md-icon-button">
               <md-icon ng-hide="expand[ind]">expand_more</md-icon>
               <md-icon ng-show="expand[ind]">expand_less</md-icon>
@@ -33,7 +33,7 @@ bios settings view
       </md-toolbar>
 
       <!-- Tabs that appear after the expand button is pressed -->
-      <section ng-slide-down='expand[ind] || false' duration='0.5'>
+      <section ng-slide-down="expand[ind] || false" duration="0.5">
         <md-tabs md-dynamic-height md-border-bottom md-stretch-tabs="always">
           <!-- Match tab -->
           <md-tab label="Match" ng-if="setting.name=='default'">
@@ -45,7 +45,7 @@ bios settings view
                   <th md-column>Action</th>
                   <th md-column>Value</th>
                   <th md-column>
-                    <md-button class='md-icon-button' ng-click='addValue(ind, "match")'>
+                    <md-button class="md-icon-button" ng-click="addValue(ind, 'match')">
                       <md-icon>add_circle_outline</md-icon>
                       <md-tooltip>Add Match Line {{session.role}} in Section {{ind}}</md-tooltip>
                     </md-button>
@@ -53,19 +53,19 @@ bios settings view
                 </tr>
               </thead>
               <tbody md-body>
-                <tr md-row ng-repeat='(k, m) in setting.match track by k'>
-                  <td md-cell><input type='text' aria-label='name' class='table-input' ng-change='biossettings.dirtyData(dirty)' ng-model='m.id'/></td>
+                <tr md-row ng-repeat="(k, m) in setting.match track by k">
+                  <td md-cell><input type="text" aria-label="name" class="table-input" ng-change="biossettings.dirtyData(dirty)" ng-model="m.id"/></td>
                   <td md-cell>
-                    <md-input-contianer class='md-block'>
-                      <md-select ng-change='biossettings.dirtyData(dirty)' ng-model='m.op' aria-label='action'>
+                    <md-input-contianer class="md-block">
+                      <md-select ng-change="biossettings.dirtyData(dirty)" ng-model="m.op" aria-label="action">
                         <md-option>exact</md-option>
                         <md-option>regex</md-option>
                       </md-select>
                     </md-input-contianer>
                   </td>
-                  <td md-cell><input ng-change='biossettings.dirtyData(dirty)' type='text' aria-label='value' class='table-input' ng-model='m.pattern' /></td>
+                  <td md-cell><input ng-change="biossettings.dirtyData(dirty)" type="text" aria-label="value" class="table-input" ng-model="m.pattern" /></td>
                   <td>
-                    <md-button class='md-icon-button' ng-click='removeValue(ind, "match", m.id)' ng-show="setting.match[k]">
+                    <md-button class="md-icon-button" ng-click="removeValue(ind, 'match', m.id)" ng-show="setting.match[k]">
                       <md-icon>clear</md-icon>
                       <md-tooltip>Remove Match Line {{v.id}} in Section {{ind}}</md-tooltip>
                     </md-button>
@@ -84,7 +84,7 @@ bios settings view
                   <th md-column>Attribute Name</th>
                   <th md-column>Value</th>
                   <th md-column>
-                    <md-button class='md-icon-button' ng-click='addValue(ind, "values")'>
+                    <md-button class="md-icon-button" ng-click="addValue(ind, 'values')">
                       <md-icon>add_circle_outline</md-icon>
                       <md-tooltip>Add Value Line {{session.role}} in Section {{ind}}</md-tooltip>
                     </md-button>
@@ -92,15 +92,15 @@ bios settings view
                 </tr>
               </thead>
               <tbody md-body>
-                <tr md-row ng-repeat='(k, v) in setting.values track by k'>
+                <tr md-row ng-repeat="(k, v) in setting.values track by k">
                   <td md-cell>
-                    <input type='text' ng-change='biossettings.dirtyData(dirty)' aria-label='name' class='table-input' ng-model='v.id' />
+                    <input type="text" ng-change="biossettings.dirtyData(dirty)" aria-label="name" class="table-input" ng-model="v.id" />
                   </td>
                   <td md-cell>
-                    <input type='text' ng-change='biossettings.dirtyData(dirty)' aria-label='name' class='table-input' ng-model='v.value' />
+                    <input type="text" ng-change="biossettings.dirtyData(dirty)" aria-label="name" class="table-input" ng-model="v.value" />
                   </td>
                   <td>
-                    <md-button class='md-icon-button' ng-click='removeValue(ind, "values", v.id)' ng-show="setting.values[k]">
+                    <md-button class="md-icon-button" ng-click="removeValue(ind, 'values', v.id)" ng-show="setting.values[k]">
                       <md-icon>clear</md-icon>
                       <md-tooltip>Remove Value {{v.id}} in Section {{ind}}</md-tooltip>
                     </md-button>
@@ -115,14 +115,14 @@ bios settings view
 
         <md-divider></md-divider>
 
-        <md-card-actions layout="row" layout-align='start center'>
+        <md-card-actions layout="row" layout-align="start center">
           <!-- Right side of toolbar -->
-          <md-card-icon-actions layout-align='end'>
-            <md-button class='md-icon-button' ng-click='createHardwareSectionPrompt($event, ind, setting.name)'>
+          <md-card-icon-actions layout-align="end">
+            <md-button class="md-icon-button" ng-click="createHardwareSectionPrompt($event, ind, setting.name)">
               <md-icon>add</md-icon>
               <md-tooltip>Add Hardware Overlay to Class {{setting.role}} Block {{setting.parent ? setting.parent : ''}} {{setting.name}}</md-tooltip>
             </md-button>
-            <md-button class='md-icon-button' ng-click='deleteSetting($event, $index)'>
+            <md-button class="md-icon-button" ng-click="deleteSetting($event, $index)">
               <md-icon>delete</md-icon>
               <md-tooltip>Destroy</md-tooltip>
             </md-button>
@@ -137,7 +137,7 @@ bios settings view
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createHardwareClassPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createHardwareClassPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Hardware Class</md-tooltip>
   </md-button>

--- a/views/bios_updates.html
+++ b/views/bios_updates.html
@@ -2,13 +2,13 @@
 bios updates view
 -->
 <div>
-  <md-card flex='100'>
-    <md-toolbar flex layout='column' md-theme='status_idle'>
-      <section layout='row'>
+  <md-card flex="100">
+    <md-toolbar flex layout="column" md-theme="status_idle">
+      <section layout="row">
         <div class="md-toolbar-tools">
           <h2>Firmware Type:</h2>
-          <md-input-contianer class='md-block'>
-            <md-select ng-change='loadUpdates()' ng-model='attribute' aria-label='action'>
+          <md-input-contianer class="md-block">
+            <md-select ng-change="loadUpdates()" ng-model="attribute" aria-label="action">
               <md-option ng-repeat="(key, value) in attributes track by key" value="{{key}}">{{ value }}</md-option>
             </md-select>
           </md-input-contianer>
@@ -17,12 +17,12 @@ bios updates view
     </md-toolbar>
   </md-card>
 
-  <md-card ng-repeat='(ind, update) in updates' flex='100'>
+  <md-card ng-repeat="(ind, update) in updates" flex="100">
 
     <div ng-show="updates[ind]">
       <!-- Top bar for each class of settings -->
-      <md-toolbar flex layout='column' md-theme='status_ready' ng-click="biosupdates.toggleExpand(ind)" md-ink-ripple>
-        <section layout='row'>
+      <md-toolbar flex layout="column" md-theme="status_ready" ng-click="biosupdates.toggleExpand(ind)" md-ink-ripple>
+        <section layout="row">
           <div class="md-toolbar-tools">
             <h2 flex>
               {{updates[ind].package.package}}
@@ -30,15 +30,15 @@ bios updates view
           </div>
           <span flex></span>
 
-          <span class='inset'>
-            <md-button class='md-icon-button' ng-show="dirty" ng-click='saveSetting($event, ind)'>
+          <span class="inset">
+            <md-button class="md-icon-button" ng-show="dirty" ng-click="saveSetting($event, ind)">
               <md-icon>save</md-icon>
               <md-tooltip>Save</md-tooltip>
             </md-button>
           </span>
 
           <!-- Expand button -->
-          <span class='inset'>
+          <span class="inset">
             <md-button class="md-icon-button">
               <md-icon ng-hide="expand[ind]">expand_more</md-icon>
               <md-icon ng-show="expand[ind]">expand_less</md-icon>
@@ -48,7 +48,7 @@ bios updates view
       </md-toolbar>
 
       <!-- Tabs that appear after the expand button is pressed -->
-      <section ng-slide-down='expand[ind]' duration='0.5'>
+      <section ng-slide-down="expand[ind]" duration="0.5">
         <md-tabs md-dynamic-height md-border-bottom md-stretch-tabs="always">
           <!-- Match tab -->
           <md-tab label="Match">
@@ -59,7 +59,7 @@ bios updates view
                   <th md-column>Attribute Name</th>
                   <th md-column>Value</th>
                   <th md-column>
-                    <md-button class='md-icon-button' ng-click='addValue(ind)'>
+                    <md-button class="md-icon-button" ng-click="addValue(ind)">
                       <md-icon>add_circle_outline</md-icon>
                       <md-tooltip>Add Match to {{update.package.package}}</md-tooltip>
                     </md-button>
@@ -67,13 +67,13 @@ bios updates view
                 </tr>
               </thead>
               <tbody md-body>
-                <tr md-row ng-repeat='(id, m) in update.match track by id'>
+                <tr md-row ng-repeat="(id, m) in update.match track by id">
                   <td md-cell>
-                    <input type='text' ng-change='biosupdates.dirtyData(dirty)' aria-label='value' class='table-input' ng-model='m.id'/></td>
+                    <input type="text" ng-change="biosupdates.dirtyData(dirty)" aria-label="value" class="table-input" ng-model="m.id"/></td>
                   <td md-cell>
-                    <input type='text' ng-change='biosupdates.dirtyData(dirty)' aria-label='value' class='table-input' ng-model='m.value'/></td>
+                    <input type="text" ng-change="biosupdates.dirtyData(dirty)" aria-label="value" class="table-input" ng-model="m.value"/></td>
                   <td>
-                    <md-button class='md-icon-button' ng-click='removeValue(ind, id)' ng-show="update.match[id]">
+                    <md-button class="md-icon-button" ng-click="removeValue(ind, id)" ng-show="update.match[id]">
                       <md-icon>clear</md-icon>
                       <md-tooltip>Remove Match Line {{id}}</md-tooltip>
                     </md-button>
@@ -95,11 +95,11 @@ bios updates view
                 </tr>
               </thead>
               <tbody md-body>
-                <tr md-row ng-repeat='(id, m) in update.package track by id'>
+                <tr md-row ng-repeat="(id, m) in update.package track by id">
                   <td md-cell>{{ id }}</td>
                   <td md-cell>
-                    <textarea ng-show='id=="script"' ng-change='biosupdates.dirtyData(dirty)' rows=5 aria-label='value' class='table-input' ng-model='m'/>
-                    <input ng-hide='id=="script"' type='text' ng-change='biosupdates.dirtyData(dirty)' aria-label='value' class='table-input' ng-model='m'/>
+                    <textarea ng-show="id=='script'" ng-change="biosupdates.dirtyData(dirty)" rows="5" aria-label="value" class="table-input" ng-model="m"/>
+                    <input ng-hide="id=='script'" type="text" ng-change="biosupdates.dirtyData(dirty)" aria-label="value" class="table-input" ng-model="m"/>
                   </td>
                 </tr>
               </tbody>
@@ -112,22 +112,22 @@ bios updates view
 
         <!-- Toolbar with icons -->
         <md-card-actions layout="row" layout-align="start center">
-          <md-button class='md-icon-button' ng-if='setting.state == 1' ng-click='saveSetting(ind)'>
+          <md-button class="md-icon-button" ng-if="setting.state == 1" ng-click="saveSetting(ind)">
             <md-icon>save</md-icon>
             <md-tooltip>Save</md-tooltip>
           </md-button>
 
-          <md-card-icon-actions layout-align='center center'>
+          <md-card-icon-actions layout-align="center center">
             <!-- Buttons in center of deployment card -->
           </md-card-icon-actions>
 
           <!-- Right side of toolbar -->
-          <md-card-icon-actions layout-align='end center'>
-            <md-button class='md-icon-button' ng-click='deleteSetting($event, ind)'>
+          <md-card-icon-actions layout-align="end center">
+            <md-button class="md-icon-button" ng-click="deleteSetting($event, ind)">
               <md-icon>delete</md-icon>
               <md-tooltip>Destroy</md-tooltip>
             </md-button>
-            <span flex='10'>
+            <span flex="10">
             </span>
           </md-card-icon-actions>
         </md-card-actions>
@@ -139,7 +139,7 @@ bios updates view
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createUpdate($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createUpdate($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Package</md-tooltip>
   </md-button>

--- a/views/capabilities.html
+++ b/views/capabilities.html
@@ -1,30 +1,30 @@
 <!--
 capabilities view
 -->
-<md-card flex='100' ng-repeat="cap in _capabilities | groupsonly | orderBy:'name'">
+<md-card flex="100" ng-repeat="cap in _capabilities | groupsonly | orderBy:'name'">
   <md-toolbar md-theme="status_{{ (cap.source=='user-defined' ? 'ready' : 'proposed') }}">
     <div class="md-toolbar-tools">
       <h2 flex>
         <md-icon aria-label="Capability" title="{{cap.source}}">traffic</md-icon>
         {{cap.name}} : {{cap.description}}
       </h2>
-      <md-button class='md-icon-button' ng-click="deleteCapability(cap)" ng-if='cap.source == "user-defined"'>
+      <md-button class="md-icon-button" ng-click="deleteCapability(cap)" ng-if="cap.source == 'user-defined'">
         <md-icon>delete</md-icon>
         <md-tooltip>Delete Capability</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click="updateCapability(cap)">
+      <md-button class="md-icon-button" ng-click="updateCapability(cap)">
         <md-icon>save</md-icon>
         <md-tooltip>Update Capability</md-tooltip>
       </md-button>
     </div>
   </md-toolbar>
   <div lazy-render duration="0.25">
-    <section layout-padding style='overflow-x: auto;'>
-      <md-chips ng-model='cap.includes' placeholder='Capabilities' md-require-match="true">
-        <md-chip-template style='font-family: monospace;'>
+    <section layout-padding style="overflow-x: auto;">
+      <md-chips ng-model="cap.includes" placeholder="Capabilities" md-require-match="true">
+        <md-chip-template style="font-family: monospace;">
           {{ $chip }}
         </md-chip-template>
-        <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in rawCapabilities(cap.includes) | filter:searchText" md-item-text="item" placeholder="Add Capability" ng-if='item != cap.name'>
+        <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in rawCapabilities(cap.includes) | filter:searchText" md-item-text="item" placeholder="Add Capability" ng-if="item != cap.name">
           <span md-highlight-text="searchText">
             {{item}}
           </span>
@@ -36,7 +36,7 @@ capabilities view
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createCapabilityPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createCapabilityPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Capaility</md-tooltip>
   </md-button>

--- a/views/deployment_roles.html
+++ b/views/deployment_roles.html
@@ -1,14 +1,14 @@
 <md-card>
-  <md-toolbar class="md-table-toolbar md-default" ng-hide='deployment_roles.selected.length'>
+  <md-toolbar class="md-table-toolbar md-default" ng-hide="deployment_roles.selected.length">
     <div class="md-toolbar-tools">
       <span flex>Deployment Roles ({{getDeploymentRoles().length}})</span>
-      <md-button class='md-icon-button' ng-href='#/roles'>
+      <md-button class="md-icon-button" ng-href="#/roles">
         <md-icon>label_outline</md-icon>
         <md-tooltip md-direction="bottom">
           Roles
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-href='#/node_roles'>
+      <md-button class="md-icon-button" ng-href="#/node_roles">
         <md-icon>dns</md-icon>
         <md-tooltip md-direction="bottom">
           Node Roles
@@ -16,11 +16,11 @@
       </md-button>    </div>
   </md-toolbar>
 
-  <md-toolbar class="md-table-toolbar alternate" ng-show='deployment_roles.selected.length'>
+  <md-toolbar class="md-table-toolbar alternate" ng-show="deployment_roles.selected.length">
     <div class="md-toolbar-tools">
       <span>{{deployment_roles.selected.length}} deployment role{{deployment_roles.selected.length != 1 && 's' || ''}} selected</span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='destroySelected()'>
+      <md-button class="md-icon-button" ng-click="destroySelected()">
         <md-icon>delete</md-icon>
         <md-tooltip>Destroy Deployment Roles</md-tooltip>
       </md-button>
@@ -28,29 +28,29 @@
   </md-toolbar>
 
   <md-table-container>
-    <table md-table md-row-select ng-model='deployment_roles.selected'>
+    <table md-table md-row-select ng-model="deployment_roles.selected">
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='deployment_id'>Deployment</th>
-          <th md-column md-order-by='role_id'>Role</th>
-          <th md-column md-order-by='id'>Deployment Role</th>
+          <th md-column md-order-by="deployment_id">Deployment</th>
+          <th md-column md-order-by="role_id">Role</th>
+          <th md-column md-order-by="id">Deployment Role</th>
         </tr>
       </thead>
       <tbody md-body>
-        <tr md-row md-select='role' md-select-id='{{role.id}}' md-auto-select ng-repeat="role in getDeploymentRoles() | orderBy: myOrder">
+        <tr md-row md-select="role" md-select-id="{{role.id}}" md-auto-select ng-repeat="role in getDeploymentRoles() | orderBy: myOrder">
           <td md-cell>
-            <a ng-href='#/dash/{{role.deployment_id}}'>
+            <a ng-href="#/dash/{{role.deployment_id}}">
             {{_deployments[role.deployment_id].name}}
           </a>
           </td>
           <td md-cell>
-            <a ng-href='#/roles/{{role.role_id}}'>
+            <a ng-href="#/roles/{{role.role_id}}">
             {{_roles[role.role_id].name}}
           </a>
           </td>
           <td md-cell>
-            <md-button ng-href='#/deployment_roles/{{role.id}}' class='md-primary md-fab md-mini'>
-              <md-icon aria-label='{{_roles[role.role_id].icon}}'>
+            <md-button ng-href="#/deployment_roles/{{role.id}}" class="md-primary md-fab md-mini">
+              <md-icon aria-label="{{_roles[role.role_id].icon}}">
                 {{_roles[role.role_id].icon}}
               </md-icon>
             </md-button>

--- a/views/deployment_roles_singular.html
+++ b/views/deployment_roles_singular.html
@@ -1,32 +1,32 @@
 <md-card>
-  <md-toolbar class="md-default" md-theme='{{ deployment_role.proposed ? "status_proposed" : "status_ready" }}' ng-style="style">
+  <md-toolbar class="md-default" md-theme="{{ deployment_role.proposed ? 'status_proposed' : 'status_ready' }}" ng-style="style">
     <div class="md-toolbar-tools">
       <span>
-        <md-icon class='md-primary'>
+        <md-icon class="md-primary">
           {{ icons[ deployment_role.proposed ? "proposed" : "ready"] }}
         </md-icon>
-        <a ng-href='#/deployments/{{deployment_role.deployment_id}}' swap-md-paint-fg="default foreground">
+        <a ng-href="#/deployments/{{deployment_role.deployment_id}}" swap-md-paint-fg="default foreground">
           {{_deployments[deployment_role.deployment_id].name}}
         </a>
-        <md-icon class='md-primary'>
+        <md-icon class="md-primary">
           {{_roles[deployment_role.role_id].icon}}
         </md-icon>
-        <a ng-href='#/roles/{{deployment_role.role_id}}' swap-md-paint-fg="default foreground">
+        <a ng-href="#/roles/{{deployment_role.role_id}}" swap-md-paint-fg="default foreground">
           {{_roles[deployment_role.role_id].name}}
         </a>
       </span>
       <span flex></span>
 
-      <md-button class='md-icon-button' ng-if='!deployment_role.proposed' ng-click='propose()'>
+      <md-button class="md-icon-button" ng-if="!deployment_role.proposed" ng-click="propose()">
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Propose</md-tooltip>
       </md-button>
 
-      <md-button class='md-icon-button' ng-if='deployment_role.proposed' ng-click='commit()'>
+      <md-button class="md-icon-button" ng-if="deployment_role.proposed" ng-click="commit()">
         <md-icon>save</md-icon>
         <md-tooltip>Commit</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='destroy()'>
+      <md-button class="md-icon-button" ng-click="destroy()">
         <md-icon>delete</md-icon>
         <md-tooltip>Destroy</md-tooltip>
       </md-button>
@@ -35,7 +35,7 @@
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
       <span>
-        <md-icon class='md-icon-button'>dashboard
+        <md-icon class="md-icon-button">dashboard
           <md-tooltip>Deployment Role</md-tooltip>
         </md-icon>
         Deployment Scope Attributes</span>
@@ -52,7 +52,7 @@
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
       <span>
-        <md-icon class='md-primary'>dns
+        <md-icon class="md-primary">dns
           <md-tooltip>Node Role</md-tooltip>
         </md-icon>
         Node Roles</span>
@@ -61,7 +61,7 @@
   <md-card-content>
     <span ng-repeat="role in _node_roles | from:'deployment':_deployments[deployment_role.deployment_id] | filter:{role_id: deployment_role.role_id} | orderBy: role.cohort()">
 
-      <md-button class="md-fab md-primary" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
+      <md-button class="md-fab md-primary" md-theme="status_{{role.status}}" ng-href="#/node_roles/{{role.id}}">
         <md-icon>{{icons[role.status]}}</md-icon>
         <md-tooltip md-direction="bottom">
           {{_nodes[role.node_id].name}}

--- a/views/deployments.html
+++ b/views/deployments.html
@@ -2,11 +2,11 @@
 deployments view
 -->
 <div>
-  <md-card ng-repeat='(id, deployment) in _deployments' flex='100'>
+  <md-card ng-repeat="(id, deployment) in _deployments" flex="100">
 
     <!-- Top bar for each deployment -->
-    <md-toolbar flex layout='column' md-theme='status_{{deploymentStates[deployment.state]}}' ng-class="{'md-warn': deployments.deploymentStatus[id].error > 0}" ng-click="deployments.toggleExpand(deployment)" md-ink-ripple>
-      <section layout='row'>
+    <md-toolbar flex layout="column" md-theme="status_{{deploymentStates[deployment.state]}}" ng-class="{'md-warn': deployments.deploymentStatus[id].error > 0}" ng-click="deployments.toggleExpand(deployment)" md-ink-ripple>
+      <section layout="row">
         <div class="md-toolbar-tools">
           <h2 flex>
             <md-icon>
@@ -24,11 +24,11 @@ deployments view
         <span flex></span>
 
         <!-- Sparkline for the nodes -->
-        <span spark class='inset' type='pie' ng-model="deployments.deploymentPie[deployment.id]" opts='{{deployments.opts}}'>
+        <span spark class="inset" type="pie" ng-model="deployments.deploymentPie[deployment.id]" opts="{{deployments.opts}}">
         </span>
 
         <!-- Expand button -->
-        <span class='inset'>
+        <span class="inset">
           <md-button class="md-icon-button">
             <md-icon ng-hide="expand[id]">expand_more</md-icon>
             <md-icon ng-show="expand[id]">expand_less</md-icon>
@@ -40,7 +40,7 @@ deployments view
       <md-progress-linear md-mode="determinate" ng-class="{'md-warn': deployments.deploymentStatus[id].error > 0}" value="{{100*(1-deployments.deploymentStatus[id].error/deployments.deploymentStatus[id].total)}}"></md-progress-linear>
     </md-toolbar>
     <!-- Tabs that appear after the expand button is pressed -->
-    <section ng-slide-down='expand[id]' duration='0.5'>
+    <section ng-slide-down="expand[id]" duration="0.5">
 
       <md-tabs md-dynamic-height md-border-bottom md-stretch-tabs="always">
 
@@ -53,7 +53,7 @@ deployments view
                 <md-tooltip md-direction="bottom">
                   {{node.name}}
                 </md-tooltip>
-                <md-icon aria-label='{{ api.getNodeStatus(node) }}'>{{ api.getNodeIcon(node) }}</md-icon>
+                <md-icon aria-label="{{ api.getNodeStatus(node) }}">{{ api.getNodeIcon(node) }}</md-icon>
               </md-button>
             </span>
 
@@ -64,37 +64,37 @@ deployments view
 
           <!-- Add all the Deployment Roles-->
           <span ng-repeat="role in _deployment_roles | from:'deployment':deployment | orderBy:_roles[role.role_id].cohort">
-            <md-button class="md-fab md-primary md-mini" ng-href='#/deployment_roles/{{role.id}}'>
+            <md-button class="md-fab md-primary md-mini" ng-href="#/deployment_roles/{{role.id}}">
               <md-tooltip md-direction="bottom">
                 {{_roles[role.role_id].name}}
               </md-tooltip>
-              <md-icon aria-label='{{_roles[role.role_id].icon}}'>{{_roles[role.role_id].icon}}</md-icon>
+              <md-icon aria-label="{{_roles[role.role_id].icon}}">{{_roles[role.role_id].icon}}</md-icon>
             </md-button>
           </span>
         </md-tab>
 
         <!-- Node/Roles Matrix tab -->
-        <md-tab label="Matrix" layout-padding layout='row'>
-          <div style='text-align: right; width: 100%;'>
-            <h3 style='margin-right: 1em'>Services</h3>
+        <md-tab label="Matrix" layout-padding layout="row">
+          <div style="text-align: right; width: 100%;">
+            <h3 style="margin-right: 1em">Services</h3>
             <span ng-repeat="role in _node_roles | from:'node':phantoms[deployment.id] | orderBy:_roles[role.role_id].cohort">
               <md-button class="md-primary md-raised square-button" md-theme="status_{{role.status}}" ng-href="#/node_roles/{{role.id}}">
                 <md-tooltip md-direction="bottom">
                   {{_roles[role.role_id].name}}
                 </md-tooltip>
-                <md-icon aria-label='role icon'>{{_roles[role.role_id].icon}}</md-icon>
+                <md-icon aria-label="role icon">{{_roles[role.role_id].icon}}</md-icon>
               </md-button>
             </span>
           </div>
-          <div style='overflow-x: auto'>
+          <div style="overflow-x: auto">
             <table>
               <thead>
                 <th></th>
                 <th valign="bottom">Nodes</th>
-                <th ng-repeat="id in matrix_order[deployment.id]" class='angled'>
+                <th ng-repeat="id in matrix_order[deployment.id]" class="angled">
                   <div>
-                    <a ng-href='#/deployment_roles/{{id}}'>
-                      <md-icon style='transform: rotateZ(45deg)'>{{_roles[_deployment_roles[id].role_id].icon}}</md-icon>
+                    <a ng-href="#/deployment_roles/{{id}}">
+                      <md-icon style="transform: rotateZ(45deg)">{{_roles[_deployment_roles[id].role_id].icon}}</md-icon>
                       {{_roles[_deployment_roles[id].role_id].name}}
                     </a>
                   </div>
@@ -104,7 +104,7 @@ deployments view
                 <tr ng-repeat="node in _nodes | from:'deployment':deployment | filter:{system: false} | orderBy:'name'">
                   <td>
                     <span>
-                      <md-icon class='status' swap-md-paint-bg="status_{{ api.getNodeStatus(node) }} primary" swap-md-paint-fg="status_{{ api.getNodeStatus(node) }} foreground">
+                      <md-icon class="status" swap-md-paint-bg="status_{{ api.getNodeStatus(node) }} primary" swap-md-paint-fg="status_{{ api.getNodeStatus(node) }} foreground">
                         {{ api.getNodeIcon(node) }}
                       </md-icon>
                       <md-tooltip>
@@ -112,12 +112,12 @@ deployments view
                       </md-tooltip>
                     </span>
                   </td>
-                  <td class='label'>
-                    <a ng-href='#/nodes/{{node.id}}' title="{{node.name}}">{{api.truncName(node.name)}}</a>
+                  <td class="label">
+                    <a ng-href="#/nodes/{{node.id}}" title="{{node.name}}">{{api.truncName(node.name)}}</a>
                   </td>
-                  <td ng-repeat='id in matrix_order[deployment.id]'>
-                    <span ng-if='matrix[deployment.id][id][node.id]'>
-                      <md-icon class='status' swap-md-paint-bg="status_{{_node_roles[matrix[deployment.id][id][node.id]].status}} primary" swap-md-paint-fg="status_{{_node_roles[matrix[deployment.id][id][node.id]].status}} foreground" ng-click='setPath("/node_roles/"+matrix[deployment.id][id][node.id])'>
+                  <td ng-repeat="id in matrix_order[deployment.id]">
+                    <span ng-if="matrix[deployment.id][id][node.id]">
+                      <md-icon class="status" swap-md-paint-bg="status_{{_node_roles[matrix[deployment.id][id][node.id]].status}} primary" swap-md-paint-fg="status_{{_node_roles[matrix[deployment.id][id][node.id]].status}} foreground" ng-click="setPath('/node_roles/'+matrix[deployment.id][id][node.id])">
                         {{icons[_node_roles[matrix[deployment.id][id][node.id]].status]}}
                       </md-icon>
                       <md-tooltip>
@@ -134,7 +134,7 @@ deployments view
         <!-- Graph tab -->
         <md-tab label="Graph">
           <div class="graph">
-            <vis-network data='graphData[deployment.id]' options='graphOptions[deployment.id]' events="{}"></vis-network>
+            <vis-network data="graphData[deployment.id]" options="graphOptions[deployment.id]" events="{}"></vis-network>
           </div>
         </md-tab>
 
@@ -143,9 +143,9 @@ deployments view
       <md-divider></md-divider>
 
       <!-- Bind Section -->
-      <md-card ng-slide-down='binding[id]' lazy-render layout='column'>
+      <md-card ng-slide-down="binding[id]" lazy-render layout="column">
         <md-toolbar flex>
-          <section layout='row'>
+          <section layout="row">
             <div class="md-toolbar-tools">
               <h2>
                 Node Role Binding 
@@ -155,7 +155,7 @@ deployments view
                 {{_roles[bindRoles[id].role_id].name}}
               </h2>
               <span flex></span>
-              <md-button class='md-icon-button' ng-click='binding[id]=false'>
+              <md-button class="md-icon-button" ng-click="binding[id]=false">
                 <md-icon>close</md-icon>
                 <md-tooltip>
                   Stop Binding Node Roles
@@ -164,9 +164,9 @@ deployments view
             </div>
           </section>
         </md-toolbar>
-        <section layout='row' style='max-height: 400px;'>
-          <md-list flex='33' style='overflow-y: auto;'>
-            <md-list-item class='md-table-toolbar alternate' ng-repeat="role in _deployment_roles | from:'deployment':deployment | orderBy: _roles[role.role_id].cohort" ng-click='setBindRole(id, role.role_id)' aria-label='Role' md-ink-ripple>
+        <section layout="row" style="max-height: 400px;">
+          <md-list flex="33" style="overflow-y: auto;">
+            <md-list-item class="md-table-toolbar alternate" ng-repeat="role in _deployment_roles | from:'deployment':deployment | orderBy: _roles[role.role_id].cohort" ng-click="setBindRole(id, role.role_id)" aria-label="Role" md-ink-ripple>
               <span flex>{{_roles[role.role_id].name}}</span>
               <span>
                   <md-icon>
@@ -177,7 +177,7 @@ deployments view
             </md-list-item>
           </md-list>
           <md-divider></md-divider>
-          <md-list style='overflow-y: auto;' flex='66'>
+          <md-list style="overflow-y: auto;" flex="66">
             <md-list-item ng-repeat="node in _nodes | from:'deployment':deployment | filter:{system: false} | orderBy: 'name'">
               <md-divider></md-divider>
 
@@ -186,29 +186,29 @@ deployments view
                 <md-tooltip md-direction="bottom">
                   {{node.status}}
                 </md-tooltip>
-                <md-icon aria-label='{{ api.getNodeStatus(node) }}'>{{ api.getNodeIcon(node) }}</md-icon>
+                <md-icon aria-label="{{ api.getNodeStatus(node) }}">{{ api.getNodeIcon(node) }}</md-icon>
               </md-button>
               <span flex>
                 {{node.name}}
               </span>
-              <span ng-show='bindRoles[id].roles[node.id]'>
+              <span ng-show="bindRoles[id].roles[node.id]">
                 <md-button class="md-fab md-primary md-mini" md-theme="status_{{bindRoles[id].roles[node.id].status}}" ng-href="#/node_roles/{{bindRoles[id].roles[node.id].id}}">
-                  <md-icon aria-label='{{bindRoles[id].roles[node.id].status}}'>
+                  <md-icon aria-label="{{bindRoles[id].roles[node.id].status}}">
                     {{icons[bindRoles[id].roles[node.id].status]}}
                   </md-icon>
                   <md-tooltip>
                     {{bindRoles[id].roles[node.id].status}}
                   </md-tooltip>
                 </md-button>
-                <md-button class='md-icon-button' ng-click='destroyNodeRole(bindRoles[id].roles[node.id].id)'>
+                <md-button class="md-icon-button" ng-click="destroyNodeRole(bindRoles[id].roles[node.id].id)">
                   <md-icon>delete</md-icon>
                   <md-tooltip>
                     Destroy Node Role
                   </md-tooltip>
                 </md-button>
               </span>
-              <span ng-hide='!bindRoles[id] || bindRoles[id].roles[node.id]'>
-                <md-button class='md-icon-button' ng-click='bindNodeRole(id, bindRoles[id].role_id, node.id)'>
+              <span ng-hide="!bindRoles[id] || bindRoles[id].roles[node.id]">
+                <md-button class="md-icon-button" ng-click="bindNodeRole(id, bindRoles[id].role_id, node.id)">
                   <md-icon>add</md-icon>
                   <md-tooltip>
                     Bind Node Role
@@ -220,32 +220,32 @@ deployments view
           </md-list>
         </section>
       </md-card>
-      <md-divider ng-show='binding[id]'></md-divider>
+      <md-divider ng-show="binding[id]"></md-divider>
 
       <!-- Toolbar with icons -->
       <md-card-actions layout="row" layout-align="start center">
-        <md-button class='md-icon-button' ng-show='deployment.state == -1' ng-click='proposeDeployment(id)'>
+        <md-button class="md-icon-button" ng-show="deployment.state == -1" ng-click="proposeDeployment(id)">
           <md-icon>build</md-icon>
           <md-tooltip>Correct</md-tooltip>
         </md-button>
 
-        <md-button class='md-icon-button' ng-show='deployment.state == 0' ng-click='commitDeployment(id)'>
+        <md-button class="md-icon-button" ng-show="deployment.state == 0" ng-click="commitDeployment(id)">
           <md-icon>save</md-icon>
           <md-tooltip>Commit</md-tooltip>
         </md-button>
 
-        <md-button class='md-icon-button' ng-show='deployment.state > 0' ng-click='proposeDeployment(id)' ng-if='!deployment.system'>
+        <md-button class="md-icon-button" ng-show="deployment.state > 0" ng-click="proposeDeployment(id)" ng-if="!deployment.system">
           <md-icon>mode_edit</md-icon>
           <md-tooltip>Propose</md-tooltip>
         </md-button>
 
-        <md-button class='md-icon-button' ng-click='showAddNodeDialog($event, id)'>
+        <md-button class="md-icon-button" ng-click="showAddNodeDialog($event, id)">
           <md-icon>add_box</md-icon>
           <md-tooltip>Add Node</md-tooltip>
         </md-button>
 
-        <md-menu md-position-mode="target-right target" ng-show='deployment.state == 0' style='padding: 0;'>
-          <md-button class='md-icon-button' ng-click='$mdOpenMenu($event)'>
+        <md-menu md-position-mode="target-right target" ng-show="deployment.state == 0" style="padding: 0;">
+          <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
             <md-icon>add_circle</md-icon>
             <md-tooltip>Add Role</md-tooltip>
           </md-button>
@@ -261,36 +261,37 @@ deployments view
           </md-menu-content>
         </md-menu>
 
-        <md-button class='md-icon-button' ng-click='binding[id]=!binding[id]'>
+        <md-button class="md-icon-button" ng-click="binding[id]=!binding[id]">
           <md-icon>link</md-icon>
           <md-tooltip>Bind Node Roles</md-tooltip>
         </md-button>
 
-        <md-card-icon-actions layout-align='center center'>
+        <md-card-icon-actions layout-align="center center">
           <!-- Buttons in center of deployment card -->
         </md-card-icon-actions>
 
         <!-- Right side of toolbar -->
-        <md-card-icon-actions layout-align='end center'>
-          <md-button class='md-icon-button' ng-if='!deployment.system' ng-click='redeployDeployment($event, id)'>
+        <md-card-icon-actions layout-align="end center">
+          <md-button class="md-icon-button" ng-if="!deployment.system" ng-click="redeployDeployment($event, id)">
             <md-icon>low_priority</md-icon>
             <md-tooltip>Redeploy All Nodes</md-tooltip>
           </md-button>
-          <md-button class='md-icon-button' ng-if='!deployment.system' ng-click='deleteDeployment($event, id)'>
+          <md-button class="md-icon-button" ng-if="!deployment.system" ng-click="deleteDeployment($event, id)">
             <md-icon>delete</md-icon>
             <md-tooltip>Destroy</md-tooltip>
           </md-button>
-          <span flex='10'>
+          <span flex="10">
           </span>
         </md-card-icon-actions>
       </md-card-actions>
 
     </section>
+  </md-card>
 </div>
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createDeploymentPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createDeploymentPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Deployment</md-tooltip>
   </md-button>

--- a/views/dhcp.html
+++ b/views/dhcp.html
@@ -1,4 +1,4 @@
-<md-card ng-repeat='subnet in _DHCP.subnets'>
+<md-card ng-repeat="subnet in _DHCP.subnets">
   <md-toolbar class="md-default" ng-click="expand[subnet.Name]=!expand[subnet.Name]">
     <div class="md-toolbar-tools">
       <span flex>
@@ -13,47 +13,47 @@
     </div>
   </md-toolbar>
 
-<div ng-slide-down='expand[subnet.Name]' lazy-render duration='0.5'>
+<div ng-slide-down="expand[subnet.Name]" lazy-render duration="0.5">
   <md-card-content>
-    <table layout-padding style='min-width: 50%;'>
+    <table layout-padding style="min-width: 50%;">
       <tr>
-        <td class='label'>Name</td>
+        <td class="label">Name</td>
         <td>
           {{subnet.name}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Subnet</td>
+        <td class="label">Subnet</td>
         <td>
           {{subnet.subnet}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Next Server</td>
+        <td class="label">Next Server</td>
         <td>
           {{subnet.next_server}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Active Start</td>
+        <td class="label">Active Start</td>
         <td>
           {{subnet.active_start}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Active End</td>
+        <td class="label">Active End</td>
         <td>
           {{subnet.active_end}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Active Lease Time</td>
+        <td class="label">Active Lease Time</td>
         <td>
           {{subnet.active_lease_time}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Reserved Lease Time</td>
+        <td class="label">Reserved Lease Time</td>
         <td>
           {{subnet.reserved_lease_time}}
         </td>
@@ -64,14 +64,14 @@
       <table md-table>
         <thead md-head md-order="leaseOrder">
           <tr md-row>
-            <th md-column md-order-by='valid'>Valid</th>
-            <th md-column md-order-by='ip'>IP</th>
-            <th md-column md-order-by='mac'>MAC</th>
-            <th md-column md-order-by='expire_time'>Expire Time</th>
+            <th md-column md-order-by="valid">Valid</th>
+            <th md-column md-order-by="ip">IP</th>
+            <th md-column md-order-by="mac">MAC</th>
+            <th md-column md-order-by="expire_time">Expire Time</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row ng-repeat='lease in subnet.leases | orderBy: leaseOrder'>
+          <tr md-row ng-repeat="lease in subnet.leases | orderBy: leaseOrder">
             <td md-cell>
               <md-icon>
                 {{lease.valid ? 'done' : 'close'}}
@@ -83,7 +83,6 @@
             <td md-cell>{{lease.ip}}</td>
             <td md-cell>{{lease.mac}}</td>
             <td md-cell>{{lease.expire_time}}</td>
-            </td>
           </tr>
         </tbody>
       </table>
@@ -94,15 +93,14 @@
       <table md-table>
         <thead md-head md-order="bindingOrder">
           <tr md-row>
-            <th md-column md-order-by='ip'>IP</th>
-            <th md-column md-order-by='mac'>MAC</th>
+            <th md-column md-order-by="ip">IP</th>
+            <th md-column md-order-by="mac">MAC</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row ng-repeat='binding in subnet.bindings | orderBy: bindingOrder'>
+          <tr md-row ng-repeat="binding in subnet.bindings | orderBy: bindingOrder">
             <td md-cell>{{binding.ip}}</td>
             <td md-cell>{{binding.mac}}</td>
-            </td>
           </tr>
         </tbody>
       </table>
@@ -113,15 +111,14 @@
       <table md-table>
         <thead md-head md-order="optionOrder">
           <tr md-row>
-            <th md-column md-order-by='id'>ID</th>
-            <th md-column md-order-by='value'>Value</th>
+            <th md-column md-order-by="id">ID</th>
+            <th md-column md-order-by="value">Value</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row ng-repeat='option in subnet.options | orderBy: optionOrder'>
+          <tr md-row ng-repeat="option in subnet.options | orderBy: optionOrder">
             <td md-cell>{{optionMap[option.id] || option.id}}</td>
             <td md-cell>{{option.value}}</td>
-            </td>
           </tr>
         </tbody>
       </table>

--- a/views/dialogs/accepteuladialog.tmpl.html
+++ b/views/dialogs/accepteuladialog.tmpl.html
@@ -1,9 +1,9 @@
-<div class='md-dialog-container' id='racknEulaDialog'>
+<div class="md-dialog-container" id="racknEulaDialog">
   <md-dialog layout-padding>
     <md-dialog-content>
-      <h2 class='md-title'>Rack<sup>N</sup> Advanced Dashboard Limited Use License Agreement</h2>
+      <h2 class="md-title">Rack<sup>N</sup> Advanced Dashboard Limited Use License Agreement</h2>
       <p>
-        Select "ACCEPT" if you accept the license stated <a target='_blank' href='https://github.com/rackn/digitalrebar-ux/blob/master/LICENSE.rst'>HERE</a>. Otherwise, select "REJECT"
+        Select "ACCEPT" if you accept the license stated <a target="_blank" href="https://github.com/rackn/digitalrebar-ux/blob/master/LICENSE.rst">HERE</a>. Otherwise, select "REJECT"
       </p>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/views/dialogs/addbootenvdialog.tmpl.html
+++ b/views/dialogs/addbootenvdialog.tmpl.html
@@ -8,92 +8,92 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label' style='width: 150px;'>Name</td>
+        <td class="label" style="width: 150px;">Name</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.Name' data-ng-readonly="locals.editing" />
+          <input type="text" class="table-input" ng-model="locals.env.Name" data-ng-readonly="locals.editing" />
         </td>
       </tr>
       <tr>
-        <td class='label'>Available</td>
+        <td class="label">Available</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.Available' />
+          <input type="text" class="table-input" ng-model="locals.env.Available" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS Name</td>
+        <td class="label">OS Name</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.Name' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.Name" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS Family</td>
+        <td class="label">OS Family</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.Family' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.Family" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS Codename</td>
+        <td class="label">OS Codename</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.Codename' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.Codename" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS Version</td>
+        <td class="label">OS Version</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.Version' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.Version" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS ISO File</td>
+        <td class="label">OS ISO File</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.IsoFile' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.IsoFile" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS ISO SHA256</td>
+        <td class="label">OS ISO SHA256</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.IsoSha256' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.IsoSha256" />
         </td>
       </tr>
       <tr>
-        <td class='label'>OS ISO Url</td>
+        <td class="label">OS ISO Url</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.OS.IsoUrl' />
+          <input type="text" class="table-input" ng-model="locals.env.OS.IsoUrl" />
         </td>
       </tr>
       <tr>
-        <td class='label'>Kernel</td>
+        <td class="label">Kernel</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.Kernel' />
+          <input type="text" class="table-input" ng-model="locals.env.Kernel" />
         </td>
       </tr>
       <tr>
-        <td class='label'>Initrds</td>
+        <td class="label">Initrds</td>
         <td>
-          <md-chips ng-model='locals.env.Initrds' placeholder='Initrds'>
-            <md-chip-template style='font-family: monospace;'>
+          <md-chips ng-model="locals.env.Initrds" placeholder="Initrds">
+            <md-chip-template style="font-family: monospace;">
               {{$chip}}
             </md-chip-template>
           </md-chips>
         </td>
       </tr>
       <tr>
-        <td class='label'>Boot Params</td>
+        <td class="label">Boot Params</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.env.BootParams' />
+          <input type="text" class="table-input" ng-model="locals.env.BootParams" />
         </td>
       </tr>
       <tr>
-        <td class='label'>Required Params</td>
+        <td class="label">Required Params</td>
         <td>
-          <md-chips ng-model='locals.env.RequiredParams' placeholder='Parameters'>
+          <md-chips ng-model="locals.env.RequiredParams" placeholder="Parameters">
             <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals.attribs | filter:searchText" md-item-text="item" placeholder="Search for an attrib">
               <span md-highlight-text="searchText">{{item}}</span>
             </md-autocomplete>
-            <md-chip-template style='font-family: monospace;'>
+            <md-chip-template style="font-family: monospace;">
               {{$chip}}
             </md-chip-template>
           </md-chips>
@@ -103,7 +103,7 @@
     <md-toolbar class="md-table-toolbar md-default">
       <div class="md-toolbar-tools">
         <span flex>Templates</span>
-        <md-button class='md-icon-button' ng-click='locals.env.Templates.push({Name:"",Path:"",UUID:""})'>
+        <md-button class="md-icon-button" ng-click="locals.env.Templates.push({Name:'',Path:'',UUID:''})">
           <md-icon>add</md-icon>
           <md-tooltip>
             Add Template
@@ -115,25 +115,25 @@
       <table md-table>
         <thead md-head md-order="templateOrder">
           <tr md-row>
-            <th md-column md-order-by='Name'>Name</th>
-            <th md-column md-order-by='Path'>Path</th>
-            <th md-column md-order-by='UUID'>UUID</th>
+            <th md-column md-order-by="Name">Name</th>
+            <th md-column md-order-by="Path">Path</th>
+            <th md-column md-order-by="UUID">UUID</th>
             <th md-column>Delete</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row ng-repeat='template in locals.env.Templates | orderBy: templateOrder'>
+          <tr md-row ng-repeat="template in locals.env.Templates | orderBy: templateOrder">
             <td md-cell>
-              <input type='text' class='table-input' ng-model='template.Name' />
+              <input type="text" class="table-input" ng-model="template.Name" />
             </td>
             <td md-cell>
-              <input type='text' class='table-input' ng-model='template.Path' />
+              <input type="text" class="table-input" ng-model="template.Path" />
             </td>
             <td md-cell>
               <md-input-container>
                 <label>UUID</label>
                 <md-select ng-model="template.UUID">
-                  <md-optgroup label='templates'>
+                  <md-optgroup label="templates">
                     <md-option ng-value="temp.UUID" ng-repeat="temp in locals._provisioner.templates">
                       {{temp.UUID}}
                     </md-option>
@@ -142,7 +142,7 @@
               </md-input-container>
             </td>
             <td>
-              <md-button class='md-icon-button' ng-click='locals.env.Templates.splice($index, 1)'>
+              <md-button class="md-icon-button" ng-click="locals.env.Templates.splice($index, 1)">
                 <md-icon>remove</md-icon>
                 <md-tooltip>
                   Remove Template
@@ -154,9 +154,9 @@
       </table>
     </md-table-container>
   </md-content>
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.createBootEnv()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createBootEnv()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/addcapabilitydialog.tmpl.html
+++ b/views/dialogs/addcapabilitydialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Capability" flex-gt-sm='50' flex='100' ng-cloak>
+<md-dialog aria-label="Capability" flex-gt-sm="50" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2><md-icon>traffic</md-icon> Capability</h2>
@@ -8,27 +8,27 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label'>Name</td>
+        <td class="label">Name</td>
         <td>
-          <input ng-if='!locals.editing' type='text' class='table-input' ng-model='locals.capability.name' />
-          <span flex ng-if='locals.editing'>{{locals.capability.name}}</span>
+          <input ng-if="!locals.editing" type="text" class="table-input" ng-model="locals.capability.name" />
+          <span flex ng-if="locals.editing">{{locals.capability.name}}</span>
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Description</td>
+        <td class="label" valign="top">Description</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.capability.description' />
+          <input type="text" class="table-input" ng-model="locals.capability.description" />
         </td>
       </tr>
     </table>
   </md-content>
 
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.createCapability()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createCapability()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/adddnsrecorddialog.tmpl.html
+++ b/views/dialogs/adddnsrecorddialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Add Record" ng-cloak flex-gt-sm='50'>
+<md-dialog aria-label="Add Record" ng-cloak flex-gt-sm="50">
   <form>
     <md-toolbar>
       <div class="md-toolbar-tools">
@@ -12,16 +12,15 @@
 
     <md-dialog-content layout-padding>
       <md-content>
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Name</label>
-          <input type='text' class='table-input' ng-model='locals.record.name' />
+          <input type="text" class="table-input" ng-model="locals.record.name" />
         </md-input-container>
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>
             Address
           </label>
-          <input type='text' class='table-input' ng-model='locals.record.content' />
-          </label>
+          <input type="text" class="table-input" ng-model="locals.record.content" />
         </md-input-container>
         <md-input-container>
           <label>Type</label>
@@ -38,7 +37,7 @@
     </md-dialog-content>
     <md-dialog-actions>
       <span flex></span>
-      <md-button ng-click='dialog.addDNSRecord()' class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.addDNSRecord()" class="md-primary md-raised" target="_blank" md-autofocus>
         Add
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/addnetworkdialog.tmpl.html
+++ b/views/dialogs/addnetworkdialog.tmpl.html
@@ -15,31 +15,31 @@
       <md-content>
         <table>
           <tr>
-            <td class='label'>
+            <td class="label">
               Category
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.category' />
+              <input type="text" class="table-input" ng-model="locals.network.category" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Group
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.group' />
+              <input type="text" class="table-input" ng-model="locals.network.group" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Description
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.description' />
+              <input type="text" class="table-input" ng-model="locals.network.description" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Deployment
             </td>
             <td>
@@ -49,67 +49,67 @@
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               VLAN
             </td>
-            <td layout='row'>
-              <md-switch ng-model="locals.network.use_vlan" aria-label="Switch" style='margin: 0;'>
+            <td layout="row">
+              <md-switch ng-model="locals.network.use_vlan" aria-label="Switch" style="margin: 0;">
                 <md-tooltip>
                   Enable/Disable VLAN
                 </md-tooltip>
               </md-switch>
-              <input type='text' class='table-input' ng-model='locals.network.vlan' />
+              <input type="text" class="table-input" ng-model="locals.network.vlan" />
             </td>
           </tr>
 
           <tr>
-            <td class='label'>
+            <td class="label">
               IPv6 Prefix
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.v6prefix' />
+              <input type="text" class="table-input" ng-model="locals.network.v6prefix" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Bridge
             </td>
-            <td layout='row'>
-              <md-switch ng-model="locals.network.use_bridge" aria-label="Switch" style='margin: 0;'>
+            <td layout="row">
+              <md-switch ng-model="locals.network.use_bridge" aria-label="Switch" style="margin: 0;">
                 <md-tooltip>
                   Enable/Disable Bridge
                 </md-tooltip>
               </md-switch>
-              <input type='text' class='table-input' ng-model='locals.network.bridge' />
+              <input type="text" class="table-input" ng-model="locals.network.bridge" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Team
             </td>
-            <td layout='row'>
-              <md-switch ng-model="locals.network.use_team" aria-label="Switch" style='margin: 0;'>
+            <td layout="row">
+              <md-switch ng-model="locals.network.use_team" aria-label="Switch" style="margin: 0;">
                 <md-tooltip>
                   Enable/Disable Team Mode
                 </md-tooltip>
               </md-switch>
-              <input type='text' class='table-input' ng-model='locals.network.team_mode' />
+              <input type="text" class="table-input" ng-model="locals.network.team_mode" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Conduit(s)
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.conduit' />
+              <input type="text" class="table-input" ng-model="locals.network.conduit" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               PBR
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.network.pbr' />
+              <input type="text" class="table-input" ng-model="locals.network.pbr" />
             </td>
           </tr>
 
@@ -119,7 +119,7 @@
     </md-dialog-content>
     <md-dialog-actions>
       <span flex></span>
-      <md-button ng-click='dialog.addNetwork()' class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.addNetwork()" class="md-primary md-raised" target="_blank" md-autofocus>
         Add
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/addnodedialog.tmpl.html
+++ b/views/dialogs/addnodedialog.tmpl.html
@@ -1,5 +1,5 @@
-<md-dialog aria-label="Add Node" ng-cloak flex-gt-sm='50'>
-  <form name='nodeForm'>
+<md-dialog aria-label="Add Node" ng-cloak flex-gt-sm="50">
+  <form name="nodeForm">
     <md-toolbar>
       <div class="md-toolbar-tools">
         <h2>Add Node</h2>
@@ -12,9 +12,9 @@
 
     <md-dialog-content layout-padding>
       <md-content>
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Name</label>
-          <input required type='text' name='name' md-minlength='1' md-maxlength='25' ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model='locals.base_name' />
+          <input required type="text" name="name" md-minlength="1" md-maxlength="25" ng-pattern="/^[a-zA-Z0-9-]{1,25}$/" ng-model="locals.base_name" />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="required">Enter a node name</div>
             <div ng-message="md-maxlength">Entered name is too long (25 char max)</div>
@@ -23,9 +23,9 @@
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Provider</label>
-          <md-select required name='provider' ng-model="locals.provider">
+          <md-select required name="provider" ng-model="locals.provider">
             <md-option ng-repeat="provider in locals._providers" value="{{provider.id}}" ng-if="!['metal','phantom'].includes(provider.name)">
               {{provider.name}}
             </md-option>
@@ -35,14 +35,14 @@
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Deployment</label>
-          <md-select required name='deployment_id' ng-model="locals.deployment_id">
+          <md-select required name="deployment_id" ng-model="locals.deployment_id">
             <md-option ng-repeat="(id, deployment) in locals._deployments" value="{{id}}">
               {{deployment.name}}
             </md-option>
           </md-select>
-          <div ng-hide='locals._deployments[locals.deployment_id].system || !locals.deployment_id' style='color: #444; font-size: smaller '>
+          <div ng-hide="locals._deployments[locals.deployment_id].system || !locals.deployment_id" style="color: #444; font-size: smaller ">
             REMINDER: Nodes in proposed non-system deployments will NOT automatically deploy
           </div>
           <div ng-messages="nodeForm.deployment_id.$error">
@@ -50,13 +50,13 @@
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block' style='padding-bottom: 16px;'>
+        <md-input-container class="md-block" style="padding-bottom: 16px;">
           <section layout-padding ng-hide="locals._profiles.length > 0">
             No Profiles Available
           </section>
-          <section layout-padding style='overflow-x: auto;' ng-if="locals._profiles.length > 0">
-            <md-chips ng-model='locals.profiles' placeholder='Profiles (optional)' md-require-match="true">
-              <md-chip-template style='font-family: monospace;'>
+          <section layout-padding style="overflow-x: auto;" ng-if="locals._profiles.length > 0">
+            <md-chips ng-model="locals.profiles" placeholder="Profiles (optional)" md-require-match="true">
+              <md-chip-template style="font-family: monospace;">
                 {{ $chip }}
               </md-chip-template>
               <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item" placeholder="Add Profiles">
@@ -68,9 +68,9 @@
           </section>
         </md-input-container>
 
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Number</label>
-          <input required type="number" name='count' step="1" ng-model="locals.number" min="1" />
+          <input required type="number" name="count" step="1" ng-model="locals.number" min="1" />
           <div ng-messages="nodeForm.count.$error">
             <div ng-message="required">Enter a number</div>
             <div ng-message="min">Enter a number greater than 0</div>
@@ -80,10 +80,10 @@
       </md-content>
     </md-dialog-content>
     <md-dialog-actions>
-      <a ng-href='#/providers'>Providers</a>
+      <a ng-href="#/providers">Providers</a>
       <br/>
       <span flex></span>
-      <md-button ng-click='dialog.editNodesInHelper()' ng-disabled='nodeForm.$error.required' class='md-icon-button md-primary' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.editNodesInHelper()" ng-disabled="nodeForm.$error.required" class="md-icon-button md-primary" target="_blank" md-autofocus>
         <md-icon>
           edit
         </md-icon>
@@ -91,7 +91,7 @@
           Edit in API Call Helper
         </md-tooltip>
       </md-button>
-      <md-button ng-click='dialog.addNodes()' ng-disabled='nodeForm.$error.required' class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.addNodes()" ng-disabled="nodeForm.$error.required" class="md-primary md-raised" target="_blank" md-autofocus>
         Add
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/addprofiledialog.tmpl.html
+++ b/views/dialogs/addprofiledialog.tmpl.html
@@ -8,19 +8,19 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label' style='width: 150px;'>Name</td>
+        <td class="label" style="width: 150px;">Name</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.profile.name' />
+          <input type="text" class="table-input" ng-model="locals.profile.name" />
         </td>
       </tr>
     </table>
     <md-toolbar class="md-table-toolbar md-default">
       <div class="md-toolbar-tools">
         <span flex>Templates</span>
-	<md-button class='md-icon-button' ng-click='dialog.profileNewValue(locals.profile.values)'>
+	<md-button class="md-icon-button" ng-click="dialog.profileNewValue(locals.profile.values)">
           <md-icon>add</md-icon>
           <md-tooltip>
             Add Value
@@ -32,18 +32,18 @@
       <table md-table>
         <thead md-head md-order="valueOrder">
           <tr md-row>
-            <th md-column md-order-by='Name'>Name</th>
-            <th md-column md-order-by='Value'>Value</th>
+            <th md-column md-order-by="Name">Name</th>
+            <th md-column md-order-by="Value">Value</th>
             <th md-column>Delete</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row ng-repeat='(key, value) in locals.profile.values | orderBy: valueOrder'>
+          <tr md-row ng-repeat="(key, value) in locals.profile.values | orderBy: valueOrder">
             <td md-cell>
               <md-input-container>
                 <label>Name</label>
                 <md-select ng-model="value.name" ng-change="dialog.profileSelectChanged(locals.profile.values, key, value.name)">
-                  <md-optgroup label='attribs'>
+                  <md-optgroup label="attribs">
                     <md-option ng-value="temp.name" ng-repeat="temp in locals.attribs">
                       {{temp.name}}
                     </md-option>
@@ -52,19 +52,19 @@
               </md-input-container>
             </td>
             <td md-cell>
-              <div style='width: calc(100% - 300px - 1em); min-height: 400px; display: inline-block;'>
-                <textarea ng-model='value.value' style='width: 100%; font-family: monospace; min-height: 400px;' ng-class="{'error': !parse(value.value, 1)||!locals.api.testSchema(parse(value.value, 0),locals.attribs[value.name].schema)}"></textarea>
+              <div style="width: calc(100% - 300px - 1em); min-height: 400px; display: inline-block;">
+                <textarea ng-model="value.value" style="width: 100%; font-family: monospace; min-height: 400px;" ng-class="{'error': !parse(value.value, 1)||!locals.api.testSchema(parse(value.value, 0),locals.attribs[value.name].schema)}"></textarea>
               </div>
-              <div style='width: 300px auto; margin-left: 1em; display: inline-block; overflow-x: auto;'>
+              <div style="width: 300px auto; margin-left: 1em; display: inline-block; overflow-x: auto;">
                 <pre>{{locals.attribs[value.name].schema | json}}</pre>
-                <span style='font-size: 1em;'>&quot;*&quot; = Required, &quot;=&quot; = Wildcard</span>
+                <span style="font-size: 1em;">&quot;*&quot; = Required, &quot;=&quot; = Wildcard</span>
 		<pre>{{value.name}} = {{locals.api.exampleFromSchema(locals.attribs[value.name].schema) | json}}</pre>
-                 <span ng-show='!parse(value.value,1)'>JSON Parsing Error</span>
-                 <span ng-show='parse(value.value,1)&&!locals.api.testSchema(parse(value.value,0),locals.attribs[value.name].schema)'>Value does not follow Schema</span>
+                 <span ng-show="!parse(value.value,1)">JSON Parsing Error</span>
+                 <span ng-show="parse(value.value,1)&&!locals.api.testSchema(parse(value.value,0),locals.attribs[value.name].schema)">Value does not follow Schema</span>
               </div>
             </td>
             <td>
-              <md-button class='md-icon-button' ng-click='dialog.profileClearData(locals.profile.values, value.name)'>
+              <md-button class="md-icon-button" ng-click="dialog.profileClearData(locals.profile.values, value.name)">
                 <md-icon>remove</md-icon>
                 <md-tooltip>
                   Remove Value
@@ -76,9 +76,9 @@
       </table>
     </md-table-container>
   </md-content>
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.createProfile()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createProfile()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/addproviderdialog.tmpl.html
+++ b/views/dialogs/addproviderdialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Add Provider" ng-cloak flex-gt-sm='50'>
+<md-dialog aria-label="Add Provider" ng-cloak flex-gt-sm="50">
   <form name="form">
     <md-toolbar>
       <div class="md-toolbar-tools">
@@ -15,55 +15,55 @@
       <md-content>
         <table>
           <tr>
-            <td class='label'>
+            <td class="label">
               Provider
             </td>
             <td>
-              <input type='text' id="name" name="name" class='table-input' ng-minlength='1' ng-required=true ng-model='locals.provider.name' />
+              <input type="text" id="name" name="name" class="table-input" ng-minlength="1" ng-required="true" ng-model="locals.provider.name" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Description
             </td>
             <td>
-              <input type='text' class='table-input' ng-model='locals.provider.description' />
+              <input type="text" class="table-input" ng-model="locals.provider.description" />
             </td>
           </tr>
-          <tbody ng-repeat='(name,options) in locals.providerTemplates[locals.provider.type]' ng-if='options' ng-switch='options.type'>
-            <tr ng-switch-when='text'>
-              <td class='label'>
+          <tbody ng-repeat="(name,options) in locals.providerTemplates[locals.provider.type]" ng-if="options" ng-switch="options.type">
+            <tr ng-switch-when="text">
+              <td class="label">
                 {{options.name}}
               </td>
               <td>
-                <input type='text' class='table-input' ng-model='locals.provider.auth_details[name]' ng-value='options.default' />
+                <input type="text" class="table-input" ng-model="locals.provider.auth_details[name]" ng-value="options.default" />
               </td>
             </tr>
 
-            <tr ng-switch-when='password'>
-              <td class='label'>
+            <tr ng-switch-when="password">
+              <td class="label">
                 {{options.name}}
               </td>
               <td>
-                <input type='password' id=password class='table-input'ng-model='locals.provider.auth_details[name]' ng-value='options.default' />
+                <input type="password" id="password" class="table-input" ng-model="locals.provider.auth_details[name]" ng-value="options.default" />
               </td>
             </tr>
 
-            <tr ng-switch-when='img'>
+            <tr ng-switch-when="img">
               <td></td>
               <td>
-                <a ng-href='{{options.href}}' target="_blank">
-                  <img ng-src='{{options.src}}' style='height: 100px; width: auto;'></a>
+                <a ng-href="{{options.href}}" target="_blank">
+                  <img ng-src="{{options.src}}" style="height: 100px; width: auto;">
                 </a>
               </td>
             </tr>
 
-            <tr ng-switch-when='json_key'>
-              <td class='label'>
+            <tr ng-switch-when="json_key">
+              <td class="label">
                 {{options.name}}
               </td>
               <td>
-                <textarea json-text class='table-input' style='font-family: monospace;' ng-model='locals.provider.auth_details[name]'>
+                <textarea json-text class="table-input" style="font-family: monospace;" ng-model="locals.provider.auth_details[name]">
                 </textarea>
               </td>
             </tr>
@@ -73,7 +73,7 @@
     </md-dialog-content>
     <md-dialog-actions>
       <span flex></span>
-      <md-button ng-click='dialog.addProvider()' ng-disabled="!form.name.$valid" class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.addProvider()" ng-disabled="!form.name.$valid" class="md-primary md-raised" target="_blank" md-autofocus>
         Add
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/addtemplatedialog.tmpl.html
+++ b/views/dialogs/addtemplatedialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Provisioner Template" flex-gt-sm='50' flex='100' ng-cloak>
+<md-dialog aria-label="Provisioner Template" flex-gt-sm="50" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2>Provisioner Template</h2>
@@ -8,31 +8,31 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label'>UUID</td>
+        <td class="label">UUID</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.template.UUID' data-ng-readonly="locals.editing" />
+          <input type="text" class="table-input" ng-model="locals.template.UUID" data-ng-readonly="locals.editing" />
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Contents</td>
+        <td class="label" valign="top">Contents</td>
         <td>
-          <textarea style='font-family: monospace; min-height: 100px;' elastic class='table-input' ng-model='locals.template.Contents'></textarea>
+          <textarea style="font-family: monospace; min-height: 100px;" elastic class="table-input" ng-model="locals.template.Contents"></textarea>
         </td>
       </tr>
     </table>
   </md-content>
 
-  <md-dialog-actions style='margin: 0;'>
-    <md-button class='md-icon-button' ng-click='selectFile()'>
+  <md-dialog-actions style="margin: 0;">
+    <md-button class="md-icon-button" ng-click="selectFile()">
       <md-icon>file_upload</md-icon>
       <md-tooltip>Upload</md-tooltip>
     </md-button>
-    <input type="file" id="file" name="file" ng-model="selectedFile" onchange='angular.element(this).scope().updateTemplateContents()' style='opacity: 0;'/>
+    <input type="file" id="file" name="file" ng-model="selectedFile" onchange="angular.element(this).scope().updateTemplateContents()" style="opacity: 0;"/>
     <span flex></span>
-    <md-button ng-click='dialog.createTemplate()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createTemplate()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/addtenantdialog.tmpl.html
+++ b/views/dialogs/addtenantdialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Tenant" flex-gt-sm='50' flex='100' ng-cloak>
+<md-dialog aria-label="Tenant" flex-gt-sm="50" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2><md-icon>group_add</md-icon> Tenant</h2>
@@ -8,24 +8,24 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label'>Name</td>
+        <td class="label">Name</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.tenant.name' />
+          <input type="text" class="table-input" ng-model="locals.tenant.name" />
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Description</td>
+        <td class="label" valign="top">Description</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.tenant.description' />
+          <input type="text" class="table-input" ng-model="locals.tenant.description" />
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Parent</td>
+        <td class="label" valign="top">Parent</td>
         <td>
-          <md-input-container class='md-block'>
+          <md-input-container class="md-block">
             <md-select ng-model="locals.tenant.parent_id" aria-label="tenant select">
               <md-option ng-repeat="(tennant_id, t) in locals.tenants" value="{{tennant_id}}">
                 {{t.name}}
@@ -37,9 +37,9 @@
     </table>
   </md-content>
 
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.createTenant()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createTenant()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/adduserdialog.tmpl.html
+++ b/views/dialogs/adduserdialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="User" flex-gt-sm='50' flex='100' ng-cloak>
+<md-dialog aria-label="User" flex-gt-sm="50" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2><md-icon>person_add</md-icon> User</h2>
@@ -8,24 +8,24 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
       <tr>
-        <td class='label'>Username</td>
+        <td class="label">Username</td>
         <td>
-          <input type='text' required class='table-input' ng-model='locals.user.username'/>
+          <input type="text" required class="table-input" ng-model="locals.user.username"/>
         </td>
       </tr>
       <tr>
-        <td class='label' required valign="top">E-Mail</td>
+        <td class="label" required valign="top">E-Mail</td>
         <td>
-          <input type='text' class='table-input' ng-model='locals.user.email'/>
+          <input type="text" class="table-input" ng-model="locals.user.email"/>
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Tenant</td>
+        <td class="label" valign="top">Tenant</td>
         <td>
-          <md-input-container class='md-block'>
+          <md-input-container class="md-block">
             <md-select ng-model="locals.user.tenant_id" aria-label="tenant select">
               <md-option ng-repeat="(tennant_id, t) in locals.tenants" value="{{tennant_id}}">
                 {{t.name}}
@@ -35,9 +35,9 @@
         </td>
       </tr>
       <tr>
-        <td class='label' ng-if='local.user.username' valign="top">Current Tenant</td>
-        <td ng-if='local.user.username'>
-          <md-input-container class='md-block'>
+        <td class="label" ng-if="local.user.username" valign="top">Current Tenant</td>
+        <td ng-if="local.user.username">
+          <md-input-container class="md-block">
             <md-select ng-model="locals.user.current_tenant_id" aria-label="tenant select">
               <md-option ng-repeat="(tennant_id, t) in locals.tenants" value="{{tennant_id}}">
                 {{t.name}}
@@ -47,22 +47,22 @@
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Password</td>
+        <td class="label" valign="top">Password</td>
         <td>
-          <input required ng-minlength=6 type='password' class='table-input' ng-model='locals.user.password1'/>
+          <input required ng-minlength=6 type="password" class="table-input" ng-model="locals.user.password1"/>
         </td>
       </tr>
       <tr>
-        <td class='label' valign="top">Re-enter Password</td>
+        <td class="label" valign="top">Re-enter Password</td>
         <td>
-          <input type='password' required ng-minlength=6  class='table-input' ng-model='locals.user.password2'/>
+          <input type="password" required ng-minlength=6  class="table-input" ng-model="locals.user.password2"/>
         </td>
       </tr>
     </table>
   </md-content>
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.createUser()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.createUser()" class="md-primary md-raised" target="_blank" md-autofocus>
       {{locals.editing ? 'Update' : 'Create'}}
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/editattribdialog.tmpl.html
+++ b/views/dialogs/editattribdialog.tmpl.html
@@ -11,21 +11,21 @@
     </md-toolbar>
 
     <!-- Network data -->
-    <md-dialog-content layout='row' style='min-width: 800px; overflow-x: hidden;'>
-      <div style='width: calc(100% - 300px - 1em); min-height: 400px; display: inline-block;'>
-        <textarea ng-model='locals.value' style='width: 100%; font-family: monospace; min-height: 400px;' ng-class="{'error': !parse(locals.value, 1) || !locals.api.testSchema(parse(locals.value), locals.attrib.schema)}"></textarea>
+    <md-dialog-content layout="row" style="min-width: 800px; overflow-x: hidden;">
+      <div style="width: calc(100% - 300px - 1em); min-height: 400px; display: inline-block;">
+        <textarea ng-model="locals.value" style="width: 100%; font-family: monospace; min-height: 400px;" ng-class="{'error': !parse(locals.value, 1) || !locals.api.testSchema(parse(locals.value), locals.attrib.schema)}"></textarea>
       </div>
-      <div style='width: 800px auto; margin-left: 1em; display: inline-block; overflow-x: auto;'>
-       <span style='font-size: 1em;'>&quot;*&quot; = Required, &quot;=&quot; = Wildcard</span>
+      <div style="width: 800px auto; margin-left: 1em; display: inline-block; overflow-x: auto;">
+       <span style="font-size: 1em;">&quot;*&quot; = Required, &quot;=&quot; = Wildcard</span>
         <pre>{{locals.api.exampleFromSchema(locals.attrib.schema) | json}}</pre>
       </div>
     </md-dialog-content>
     <md-dialog-actions>
-      <span ng-show='!parse(locals.value,1)'>JSON Parsing Error</span>
-      <span ng-show='parse(locals.value,1) && !locals.api.testSchema(parse(locals.value), locals.attrib.schema)'>Value does not follow Schema</span>
+      <span ng-show="!parse(locals.value,1)">JSON Parsing Error</span>
+      <span ng-show="parse(locals.value,1) && !locals.api.testSchema(parse(locals.value), locals.attrib.schema)">Value does not follow Schema</span>
       <span flex></span>
-      <md-button ng-click='dialog.editAttrib(locals.target)' class='md-primary md-raised' target="_blank" md-autofocus ng-disabled="!parse(locals.value,1)">
-        <span ng-show='!locals.api.testSchema(parse(locals.value), locals.attrib.schema)'>Force</span>
+      <md-button ng-click="dialog.editAttrib(locals.target)" class="md-primary md-raised" target="_blank" md-autofocus ng-disabled="!parse(locals.value,1)">
+        <span ng-show="!locals.api.testSchema(parse(locals.value), locals.attrib.schema)">Force</span>
         Update
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/editcapabilitiesdialog.tmpl.html
+++ b/views/dialogs/editcapabilitiesdialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="User {{locals.user.username}} Capabilities" flex-gt-sm='50' flex='100' ng-cloak>
+<md-dialog aria-label="User {{locals.user.username}} Capabilities" flex-gt-sm="50" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2><md-icon>person</md-icon> {{locals.user.username}} Capabilities</h2>
@@ -8,21 +8,21 @@
       </md-button>
     </div>
   </md-toolbar>
-  <md-content style='overflow-y: auto;'>
-    <table style='width: 90%; overflow-x: hidden;'>
-      <tr ng-repeat='tenant in locals.tenants'>
-        <td class='label' valign="top">
+  <md-content style="overflow-y: auto;">
+    <table style="width: 90%; overflow-x: hidden;">
+      <tr ng-repeat="tenant in locals.tenants">
+        <td class="label" valign="top">
           {{tenant.name}}
         </td>
         <td>
-          <md-chips ng-model='locals.user.caps[tenant.id].caps' placeholder='Capabilities' md-require-match="true" md-on-add="fixCaps(tenant)">
+          <md-chips ng-model="locals.user.caps[tenant.id].caps" placeholder="Capabilities" md-require-match="true" md-on-add="fixCaps(tenant)">
             <!-- md-on-add only works with the first tenant, not the 2nd for some reason....... -->
-            <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals.capabilitiesList| filter:searchText" md-item-text="item.name" placeholder="Search for a Capability" ng-if='!locals.user.caps[tenant.id].caps.includes(item)'>
+            <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals.capabilitiesList| filter:searchText" md-item-text="item.name" placeholder="Search for a Capability" ng-if="!locals.user.caps[tenant.id].caps.includes(item)">
               <span md-highlight-text="searchText">
                 {{item.name}}
               </span>
             </md-autocomplete>
-            <md-chip-template style='font-family: monospace;'>
+            <md-chip-template style="font-family: monospace;">
               {{locals.capabilities[$chip].name}}
             </md-chip-template>
           </md-chips>
@@ -30,9 +30,9 @@
       </tr>
     </table>
   </md-content>
-  <md-dialog-actions style='margin: 0;'>
+  <md-dialog-actions style="margin: 0;">
     <span flex></span>
-    <md-button ng-click='dialog.updateUserCaps()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.updateUserCaps()" class="md-primary md-raised" target="_blank" md-autofocus>
       Update
     </md-button>
   </md-dialog-actions>

--- a/views/dialogs/editnodedialog.tmpl.html
+++ b/views/dialogs/editnodedialog.tmpl.html
@@ -1,5 +1,5 @@
-<md-dialog aria-label="Edit Node" ng-cloak flex-gt-sm='50'>
-  <form name='nodeForm'>
+<md-dialog aria-label="Edit Node" ng-cloak flex-gt-sm="50">
+  <form name="nodeForm">
     <md-toolbar>
       <div class="md-toolbar-tools">
         <h2>Edit Node {{locals.node.name}}</h2>
@@ -12,9 +12,9 @@
 
     <md-dialog-content layout-padding>
       <md-content>
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Name</label>
-          <input required type='text' name='name1' md-minlength='1' md-maxlength='60' ng-pattern="/^[a-zA-Z0-9-.]{1,60}$/" ng-model='locals.name1' />
+          <input required type="text" name="name1" md-minlength="1" md-maxlength="60" ng-pattern="/^[a-zA-Z0-9-.]{1,60}$/" ng-model="locals.name1" />
           <div ng-messages="nodeForm.name1.$error">
             <div ng-message="required">Enter a node name</div>
             <div ng-message="md-maxlength">Entered name is too long (60 char max)</div>
@@ -23,21 +23,21 @@
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <label>Description</label>
-          <input required type='text' name='description1' md-required="false" md-maxlength='80' ng-model='locals.description1' />
+          <input required type="text" name="description1" md-required="false" md-maxlength="80" ng-model="locals.description1" />
           <div ng-messages="nodeForm.name.$error">
             <div ng-message="md-maxlength">Entered name is too long (80 char max)</div>
           </div>
         </md-input-container>
 
-        <md-input-container class='md-block' style='padding-bottom: 16px;'>
+        <md-input-container class="md-block" style="padding-bottom: 16px;">
           <section layout-padding ng-hide="locals._profiles.length > 0">
             No Profiles Available
           </section>
-          <section layout-padding style='overflow-x: auto;' ng-if="locals._profiles.length > 0">
-            <md-chips ng-model='locals.profiles1' placeholder='Profiles (optional)' md-require-match="true">
-              <md-chip-template style='font-family: monospace;'>
+          <section layout-padding style="overflow-x: auto;" ng-if="locals._profiles.length > 0">
+            <md-chips ng-model="locals.profiles1" placeholder="Profiles (optional)" md-require-match="true">
+              <md-chip-template style="font-family: monospace;">
                 {{ $chip }}
               </md-chip-template>
               <md-autocomplete md-selected-item="selectedItem" md-search-text="searchText" md-items="item in locals._profiles | filter:searchText" md-item-text="item" placeholder="Add Profiles">
@@ -52,7 +52,7 @@
       </md-content>
     </md-dialog-content>
     <md-dialog-actions>
-      <md-button ng-click='dialog.updateNode()' ng-disabled='nodeForm.$error.required' class='md-primary md-raised' target="_blank" md-autofocus>
+      <md-button ng-click="dialog.updateNode()" ng-disabled="nodeForm.$error.required" class="md-primary md-raised" target="_blank" md-autofocus>
         save
       </md-button>
     </md-dialog-actions>

--- a/views/dialogs/euladialog.tmpl.html
+++ b/views/dialogs/euladialog.tmpl.html
@@ -9,7 +9,7 @@
         </md-button>
       </div>
     </md-toolbar>
-    <md-dialog-content layout-padding style='overflow-x: hidden;'>
+    <md-dialog-content layout-padding style="overflow-x: hidden;">
       <pre>
 				{{locals.eula}}
 			</pre>

--- a/views/dialogs/updatebarclampdialog.tmpl.html
+++ b/views/dialogs/updatebarclampdialog.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Barclamp ({{locals.barclamp.name}})" flex-gt-sm='40' flex='100' ng-cloak>
+<md-dialog aria-label="Barclamp ({{locals.barclamp.name}})" flex-gt-sm="40" flex="100" ng-cloak>
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2>Barclamp ({{locals.barclamp.name}})</h2>
@@ -9,11 +9,11 @@
     </div>
   </md-toolbar>
 
-  <textarea json-text style='font-family: monospace;' rows="20" ng-model='locals.barclamp.cfg_data'></textarea>
+  <textarea json-text style="font-family: monospace;" rows="20" ng-model="locals.barclamp.cfg_data"></textarea>
 
   <md-dialog-actions>
     <span flex></span>
-    <md-button ng-click='dialog.updateBarclamp()' class='md-primary md-raised' target="_blank" md-autofocus>
+    <md-button ng-click="dialog.updateBarclamp()" class="md-primary md-raised" target="_blank" md-autofocus>
       Update
     </md-button>
   </md-dialog-actions>

--- a/views/dns.html
+++ b/views/dns.html
@@ -1,4 +1,4 @@
-<md-card ng-repeat='zone in _DNS.zones'>
+<md-card ng-repeat="zone in _DNS.zones">
   <md-toolbar class="md-default">
     <div class="md-toolbar-tools">
       <span flex>
@@ -8,20 +8,20 @@
   </md-toolbar>
 
   <md-card-content>
-    <table layout-padding style='min-width: 50%;'>
+    <table layout-padding style="min-width: 50%;">
       <tr>
-        <td class='label'>Name</td>
+        <td class="label">Name</td>
         <td>
           {{zone.name}}
         </td>
       </tr>
     </table>
 
-    <md-toolbar class="md-table-toolbar md-default" ng-hide='dns.selected.length'>
+    <md-toolbar class="md-table-toolbar md-default" ng-hide="dns.selected.length">
       <div class="md-toolbar-tools">
         <span>Records</span>
         <span flex></span>
-        <md-button class='md-icon-button' ng-click='add($event, zone)'>
+        <md-button class="md-icon-button" ng-click="add($event, zone)">
           <md-icon>add</md-icon>
           <md-tooltip>Add Record</md-tooltip>
         </md-button>
@@ -29,11 +29,11 @@
       </div>
     </md-toolbar>
 
-    <md-toolbar class="md-table-toolbar alternate" ng-show='dns.selected.length'>
+    <md-toolbar class="md-table-toolbar alternate" ng-show="dns.selected.length">
       <div class="md-toolbar-tools">
         <span>{{dns.selected.length}} record{{dns.selected.length != 1 && 's' || ''}} selected</span>
         <span flex></span>
-        <md-button class='md-icon-button' ng-click='deleteRecords(zone)'>
+        <md-button class="md-icon-button" ng-click="deleteRecords(zone)">
           <md-icon>delete</md-icon>
           <md-tooltip>Delete Records</md-tooltip>
         </md-button>
@@ -44,17 +44,16 @@
       <table md-table md-row-select ng-model="dns.selected">
         <thead md-head md-order="myOrder">
           <tr md-row>
-            <th md-column md-order-by='name'>Name</th>
-            <th md-column md-order-by='content'>Content</th>
-            <th md-column md-order-by='type'>Type</th>
+            <th md-column md-order-by="name">Name</th>
+            <th md-column md-order-by="content">Content</th>
+            <th md-column md-order-by="type">Type</th>
           </tr>
         </thead>
         <tbody md-body>
-          <tr md-row md-select="record" md-select-id="{{record}}" md-auto-select ng-repeat='record in zone.records | orderBy:myOrder'>
+          <tr md-row md-select="record" md-select-id="{{record}}" md-auto-select ng-repeat="record in zone.records | orderBy:myOrder">
             <td md-cell>{{record.name}}</td>
             <td md-cell>{{record.content}}</td>
             <td md-cell>{{record.type}}</td>
-            </td>
           </tr>
         </tbody>
       </table>

--- a/views/engine.html
+++ b/views/engine.html
@@ -1,8 +1,8 @@
-<md-card ng-repeat='ruleset in _engine'>
+<md-card ng-repeat="ruleset in _engine">
   <md-toolbar class="md-default">
     <div class="md-toolbar-tools">
       <span flex>
-        <md-button class='md-icon-button' ng-click=''>
+        <md-button class="md-icon-button" ng-click="">
           <md-icon>{{ ruleset.Active ? "visibility" : "visibility_off"}}</md-icon>
           <md-tooltip>{{ ruleset.Active ? "Active" : "Inactive"}}</md-tooltip>
         </md-button>
@@ -38,16 +38,16 @@
           </td>
           <td md-cell>
             <span flex ng-repeat="match in rule.Matchers">
-              <div flex ng-if='match.JSON'><strong>JSON:</strong> {{match.JSON}}</div>
-              <div flex ng-if='match.Eq'><strong>Equals:</strong> {{match.Eq}}</div>
-              <div flex ng-if='!match.Eq || !match.JSON'>{{match.Eq}}</div>
+              <div flex ng-if="match.JSON"><strong>JSON:</strong> {{match.JSON}}</div>
+              <div flex ng-if="match.Eq"><strong>Equals:</strong> {{match.Eq}}</div>
+              <div flex ng-if="!match.Eq || !match.JSON">{{match.Eq}}</div>
             </span>
           </td>
           <td md-cell>
             <span flex ng-repeat="action in rule.Actions">
-              <div flex ng-if='action.Bind'><strong>Bind:</strong>{{action.Bind}}</div>
-              <div flex ng-if='action.Node'><strong>Node:</strong>{{action.Node}}</div>
-              <div flex ng-if='!action.Node || !action.Bind'>{{action}}</div>
+              <div flex ng-if="action.Bind"><strong>Bind:</strong>{{action.Bind}}</div>
+              <div flex ng-if="action.Node"><strong>Node:</strong>{{action.Node}}</div>
+              <div flex ng-if="!action.Node || !action.Bind">{{action}}</div>
             </span>
           </td>
         </tbody>

--- a/views/graphs.html
+++ b/views/graphs.html
@@ -1,73 +1,73 @@
-<md-card flex class='graph-card'>
+<md-card flex class="graph-card">
   <div ng-switch="hasGraph">
-    <md-card-content ng-switch-when="-1" style='margin-top: 4em'>
+    <md-card-content ng-switch-when="-1" style="margin-top: 4em">
       <div layout="row" layout-sm="column" layout-align="space-around">
         <md-progress-circular md-mode="indeterminate"></md-progress-circular>
       </div>
     </md-card-content>
-    <md-card-content ng-switch-when="0" style='margin-top: 4em'>
+    <md-card-content ng-switch-when="0" style="margin-top: 4em">
       Error Loading Graph
     </md-card-content>
-    <md-card-content ng-switch-when="1"  style='padding: 0;'>
+    <md-card-content ng-switch-when="1"  style="padding: 0;">
       <div class="graph">
-        <vis-network data='graphData' options='graphOptions' events="{}"></vis-network>
+        <vis-network data="graphData" options="graphOptions" events="{}"></vis-network>
       </div>
     </md-card-content>
   </div>
-  <section class='graph-overlay' layout-gt-sm='row' layout='column'>
-    <md-input-container style='margin: 0 1em 0 1em;'>
-      <md-select ng-model='graphType' ng-change='getGraph()' aria-label="select">
-        <md-option value='node_roles'>Node Role</md-option>
-        <md-option value='roles'>Role</md-option>
+  <section class="graph-overlay" layout-gt-sm="row" layout="column">
+    <md-input-container style="margin: 0 1em 0 1em;">
+      <md-select ng-model="graphType" ng-change="getGraph()" aria-label="select">
+        <md-option value="node_roles">Node Role</md-option>
+        <md-option value="roles">Role</md-option>
       </md-select>
     </md-input-container>
 
-    <md-input-container style='margin: 0 1em 0 1em;' ng-show="graphType == 'node_roles'">
-      <md-select ng-model='graphDeployment' ng-change='getGraph()' aria-label="select">
-        <md-option value='0'>No Deployment</md-option>
-        <md-option ng-repeat="(id, deployment) in _deployments" value='{{id}}'>
+    <md-input-container style="margin: 0 1em 0 1em;" ng-show="graphType == 'node_roles'">
+      <md-select ng-model="graphDeployment" ng-change="getGraph()" aria-label="select">
+        <md-option value="0">No Deployment</md-option>
+        <md-option ng-repeat="(id, deployment) in _deployments" value="{{id}}">
           {{deployment.name}}
         </md-option>
       </md-select>
     </md-input-container>
 
-    <md-input-container style='margin: 0 1em 0 1em;' ng-show="graphType == 'node_roles'">
-      <md-select ng-model='graphNode' ng-change='getGraph()' aria-label="select">
-        <md-option value='0'>No Node</md-option>
-        <md-option ng-repeat="(id, node) in _nodes" ng-if="node.variant != 'phantom'" value='{{id}}'>
+    <md-input-container style="margin: 0 1em 0 1em;" ng-show="graphType == 'node_roles'">
+      <md-select ng-model="graphNode" ng-change="getGraph()" aria-label="select">
+        <md-option value="0">No Node</md-option>
+        <md-option ng-repeat="(id, node) in _nodes" ng-if="node.variant != 'phantom'" value="{{id}}">
           {{node.name}}
         </md-option>
       </md-select>
     </md-input-container>
 
-    <md-input-container style='margin: 0 1em 0 1em;'>
-      <md-select ng-model='graphRole' ng-change='getGraph()' aria-label="select">
-        <md-option value='0'>No Role</md-option>
-        <md-option ng-repeat="(id, role) in _roles" value='{{id}}'>
-          <md-icon style='margin: 0 8px 4px 0;'>{{role.icon}}</md-icon>
+    <md-input-container style="margin: 0 1em 0 1em;">
+      <md-select ng-model="graphRole" ng-change="getGraph()" aria-label="select">
+        <md-option value="0">No Role</md-option>
+        <md-option ng-repeat="(id, role) in _roles" value="{{id}}">
+          <md-icon style="margin: 0 8px 4px 0;">{{role.icon}}</md-icon>
           {{role.name}}
         </md-option>
       </md-select>
     </md-input-container>
 
-    <md-input-container style='margin: 0 1em 0 1em;' ng-show="graphType == 'roles'">
-      <md-select ng-model='graphBarclamp' ng-change='getGraph()' aria-label="select">
-        <md-option value='0'>No Barclamp</md-option>
-        <md-option ng-repeat="(id, barclamp) in _barclamps" value='{{id}}'>
+    <md-input-container style="margin: 0 1em 0 1em;" ng-show="graphType == 'roles'">
+      <md-select ng-model="graphBarclamp" ng-change="getGraph()" aria-label="select">
+        <md-option value="0">No Barclamp</md-option>
+        <md-option ng-repeat="(id, barclamp) in _barclamps" value="{{id}}">
           {{barclamp.name}}
         </md-option>
       </md-select>
     </md-input-container>
 
     <div>
-      <md-checkbox ng-model="graphHLayout" aria-label="checkbox" style='margin: 8px 8px 8px 16px;'>
+      <md-checkbox ng-model="graphHLayout" aria-label="checkbox" style="margin: 8px 8px 8px 16px;">
         Hierarchical Layout
       </md-checkbox>
     </div>
 
     <span flex></span>
 
-    <md-button class='md-icon-button' ng-click='getGraph()'> 
+    <md-button class="md-icon-button" ng-click="getGraph()"> 
       <md-icon>
         refresh
       </md-icon>

--- a/views/logging.html
+++ b/views/logging.html
@@ -1,30 +1,30 @@
-<md-card layout='column' flex>
-  <md-toolbar class='md-table-toolbar'>
-    <div class='md-toolbar-tools'>
-      <md-icon style='color: #fff;'>
+<md-card layout="column" flex>
+  <md-toolbar class="md-table-toolbar">
+    <div class="md-toolbar-tools">
+      <md-icon style="color: #fff;">
         search
       </md-icon>
-      <input type="text" class='table-input' style='background: rgba(0,0,0,0); color: #fff;' ng-model="search" placeholder="Search Errors">
+      <input type="text" class="table-input" style="background: rgba(0,0,0,0); color: #fff;" ng-model="search" placeholder="Search Errors">
     </div>
   </md-toolbar>
 
-  <div style='text-align: center; padding: 1em;' ng-if='!api.errors.length'>
+  <div style="text-align: center; padding: 1em;" ng-if="!api.errors.length">
     No Errors To Display
   </div>
-  <md-table-container ng-if='api.errors.length'>
+  <md-table-container ng-if="api.errors.length">
     <table md-table>
       <thead md-head md-order="order">
         <tr md-row>
-          <th md-column md-order-by='type'>Type</th>
-          <th md-column md-order-by='message'>Message</th>
-          <th md-column md-order-by='date'>Date</th>
+          <th md-column md-order-by="type">Type</th>
+          <th md-column md-order-by="message">Message</th>
+          <th md-column md-order-by="date">Date</th>
         </tr>
       </thead>
       <tbody md-body>
         <tr md-row ng-repeat="error in api.errors | filter:search | orderBy: order | limitTo:query.limit:(query.page-1)*query.limit">
           <td md-cell>{{error.type}}</td>
           <td md-cell>
-            <md-button class='md-icon-button' ng-click='showInfo($event, error)'>
+            <md-button class="md-icon-button" ng-click="showInfo($event, error)">
               <md-icon>
                 info_outline
               </md-icon>
@@ -36,7 +36,7 @@
           </td>
           <td md-cell>{{error.date | date:'MM-dd-yy hh:mm:ssa'}}</td>
           <td md-cell>
-            <md-button class='md-icon-button' ng-click='remove(error)'>
+            <md-button class="md-icon-button" ng-click="remove(error)">
               <md-icon>
                 remove
               </md-icon>
@@ -49,5 +49,5 @@
       </tbody>
     </table>
   </md-table-container>
-  <md-table-pagination ng-if='api.errors.length' md-limit="query.limit" md-limit-options="[10, 25, 50]" md-page="query.page" md-total="{{api.errors.length}}" md-page-select></md-table-pagination>
+  <md-table-pagination ng-if="api.errors.length" md-limit="query.limit" md-limit-options="[10, 25, 50]" md-page="query.page" md-total="{{api.errors.length}}" md-page-select></md-table-pagination>
 </md-card>

--- a/views/login.html
+++ b/views/login.html
@@ -2,65 +2,65 @@
 login view
 -->
 
-<div layout='wrap' layout-align="center center" ng-if='!initialRemember' style='min-height: 100vh;'>
+<div layout="wrap" layout-align="center center" ng-if="!initialRemember" style="min-height: 100vh;">
 
-  <form name='loginForm' ng-submit='login.signIn()' layout="column">
+  <form name="loginForm" ng-submit="login.signIn()" layout="column">
 
-    <div layout='column'>
-      <p layout='column'>
-        <img src='css/logo_trans.png' style='max-width: 300px;' />
-        <span class='md-subhead' style='color: #444; text-align: center;'>
+    <div layout="column">
+      <p layout="column">
+        <img src="css/logo_trans.png" style="max-width: 300px;" />
+        <span class="md-subhead" style="color: #444; text-align: center;">
           Rack<sup>N</sup> Advanced Dashboard
         </span>
       </p>
 
       <!-- Username and password fields -->
-      <md-input-container class="md-block" style='margin-bottom: 0;' flex>
+      <md-input-container class="md-block" style="margin-bottom: 0;" flex>
         <md-icon>
           person
         </md-icon>
         <label>Username</label>
-        <input type="text" ng-model='login.credentials.username' />
+        <input type="text" ng-model="login.credentials.username" />
       </md-input-container>
 
-      <md-input-container class="md-block" style='margin-bottom: 0; margin-top: 0;' flex>
+      <md-input-container class="md-block" style="margin-bottom: 0; margin-top: 0;" flex>
         <md-icon>
           lock
         </md-icon>
         <label>Password</label>
-        <input type="password" ng-model='login.credentials.password' />
+        <input type="password" ng-model="login.credentials.password" />
       </md-input-container>
 
-      <div layout='row'>
-        <div style='padding: 4px 8px 8px 0;'>
-          <span ng-show='login.state == -1'>
-            <md-icon style='color: black;'>close</md-icon>
+      <div layout="row">
+        <div style="padding: 4px 8px 8px 0;">
+          <span ng-show="login.state == -1">
+            <md-icon style="color: black;">close</md-icon>
             <md-tooltip>
               Invalid Endpoint
             </md-tooltip>
           </span>
-          <span ng-show='login.state == 1'>
-            <md-icon style='color: black;'>check</md-icon>
+          <span ng-show="login.state == 1">
+            <md-icon style="color: black;">check</md-icon>
             <md-tooltip>
               Valid Endpoint!
             </md-tooltip>
           </span>
-          <span ng-show='login.state == 0'>
-            <md-icon style='color: black;' class='rotate'>hourglass_empty</md-icon>
+          <span ng-show="login.state == 0">
+            <md-icon style="color: black;" class="rotate">hourglass_empty</md-icon>
             <md-tooltip>
               Validating Endpoint...
             </md-tooltip>
           </span>
         </div>
 
-        <md-autocomplete flex class="md-block login-autocomplete" ng-init='search=login.host' md-selected-item="selected" md-search-text="search" md-search-text-change="login.host=search;delayTest()" md-items="item in login.hosts | filter:search" md-selected-item-change="login.host=selected||search;delayTest()" md-item-text="item" ng-model-options="{ debounce: 500 }" md-floating-label="API Endpoint">
+        <md-autocomplete flex class="md-block login-autocomplete" ng-init="search=login.host" md-selected-item="selected" md-search-text="search" md-search-text-change="login.host=search;delayTest()" md-items="item in login.hosts | filter:search" md-selected-item-change="login.host=selected||search;delayTest()" md-item-text="item" ng-model-options="{ debounce: 500 }" md-floating-label="API Endpoint">
           <md-item-template>
             <span md-highlight-text="search">{{item}}</span>
           </md-item-template>
         </md-autocomplete>
 
         <div>
-          <md-button class="md-icon-button md-primary" ng-click='login.showEulaDialog($event)' ng-show="login.state == 1" style='margin-top: -4px'>
+          <md-button class="md-icon-button md-primary" ng-click="login.showEulaDialog($event)" ng-show="login.state == 1" style="margin-top: -4px">
             <md-icon>
               info_outline
             </md-icon>
@@ -69,7 +69,7 @@ login view
             </md-tooltip>
           </md-button>
 
-          <md-button class='md-icon-button md-primary' ng-click='delayTest()' ng-show='login.state != 1'>
+          <md-button class="md-icon-button md-primary" ng-click="delayTest()" ng-show="login.state != 1">
             <md-icon>
               refresh
             </md-icon>
@@ -80,8 +80,8 @@ login view
         </div>
       </div>
 
-      <div layout-align="start end" layout='row'>
-        <md-button class='md-icon-button md-primary' target='_blank' ng-href='http://digital-rebar.readthedocs.io/en/latest/BOOK.html'>
+      <div layout-align="start end" layout="row">
+        <md-button class="md-icon-button md-primary" target="_blank" ng-href="http://digital-rebar.readthedocs.io/en/latest/BOOK.html">
           <md-icon>
             help_outline
           </md-icon>
@@ -90,8 +90,8 @@ login view
           </md-tooltip>
         </md-button>
         <span flex></span>
-        <div style='padding: 8px;'>
-          <md-switch ng-model="acceptedEula" ng-disabled='!acceptedEula' aria-label="eula switch" ng-click='acceptEula($event)' style='margin: 0;'>
+        <div style="padding: 8px;">
+          <md-switch ng-model="acceptedEula" ng-disabled="!acceptedEula" aria-label="eula switch" ng-click="acceptEula($event)" style="margin: 0;">
             License
           </md-switch>
         </div>
@@ -101,9 +101,8 @@ login view
         </md-button>
       </div>
 
-      <div style='text-align: center; color: #aaa; margin-top: 8px;'>
-      powered by Digital Rebar <a href='http://rebar.digital' style='margin-top: 5px;'><img src='css/dr_icon.png' style='height: 15px; opacity: 0.7;'/></a></div>
-      </div>
+      <div style="text-align: center; color: #aaa; margin-top: 8px;">
+      powered by Digital Rebar <a href="http://rebar.digital" style="margin-top: 5px;"><img src="css/dr_icon.png" style="height: 15px; opacity: 0.7;"/></a></div>
 
     </div>
 
@@ -111,10 +110,10 @@ login view
 
 </div>
 
-<div ng-if='initialRemember' layout-fill layout-align='center center' style='position: relative; padding-top: 25%;'>
-  <div class='centered' style='width: 100%; text-align: center; transform: translateY(-50%);'>
-    <h1 class='md-header'>Signing You In...</h1>
+<div ng-if="initialRemember" layout-fill layout-align="center center" style="position: relative; padding-top: 25%;">
+  <div class="centered" style="width: 100%; text-align: center; transform: translateY(-50%);">
+    <h1 class="md-header">Signing You In...</h1>
     <md-progress-circular md-mode="indeterminate"></md-progress-circular>
-    <md-button class='md-primary' ng-click='cancelInitial()'>Cancel</md-button>
+    <md-button class="md-primary" ng-click="cancelInitial()">Cancel</md-button>
   </div>
 </div>

--- a/views/networks.html
+++ b/views/networks.html
@@ -1,18 +1,18 @@
 <md-card>
 
-  <md-toolbar class="md-table-toolbar md-default" ng-hide='networks.selected.length'>
+  <md-toolbar class="md-table-toolbar md-default" ng-hide="networks.selected.length">
     <div class="md-toolbar-tools">
       <span>Networks ({{networks.getNetworks().length}})</span>
       <span flex></span>
     </div>
   </md-toolbar>
 
-  <md-toolbar class="md-table-toolbar alternate" ng-show='networks.selected.length'>
+  <md-toolbar class="md-table-toolbar alternate" ng-show="networks.selected.length">
     <div class="md-toolbar-tools">
       <span>{{networks.selected.length}} network{{networks.selected.length != 1 && 's' || ''}} selected</span>
       <span flex></span>
       <md-menu md-position-mode="target-right target">
-        <md-button class='md-icon-button' ng-click="$mdOpenMenu($event)">
+        <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
           <md-icon>swap_horiz</md-icon>
           <md-tooltip>Move Networks</md-tooltip>
         </md-button>
@@ -28,7 +28,7 @@
         </md-menu-content>
       </md-menu>
       <md-menu md-position-mode="target-right target">
-        <md-button class='md-icon-button' ng-click="$mdOpenMenu($event)">
+        <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
           <md-icon>group</md-icon>
           <md-tooltip>Change Network Tenant</md-tooltip>
         </md-button>
@@ -44,7 +44,7 @@
         </md-menu-content>
       </md-menu>
       
-      <md-button class='md-icon-button' ng-click='networks.deleteSelected()'>
+      <md-button class="md-icon-button" ng-click="networks.deleteSelected()">
         <md-icon>delete</md-icon>
         <md-tooltip>Remove Networks</md-tooltip>
       </md-button>
@@ -52,26 +52,26 @@
   </md-toolbar>
 
   <md-table-container>
-    <table md-table md-row-select ng-model='networks.selected'>
+    <table md-table md-row-select ng-model="networks.selected">
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='name'>Name</th>
+          <th md-column md-order-by="name">Name</th>
           <th md-column>Description</th>
-          <th md-column md-order-by='category'>Category</th>
-          <th md-column md-order-by='group'>Group</th>
-          <th md-column md-order-by='deployment_id'>Deployment</th>
-          <th md-column md-order-by='tenant_id'>Tenant</th>
+          <th md-column md-order-by="category">Category</th>
+          <th md-column md-order-by="group">Group</th>
+          <th md-column md-order-by="deployment_id">Deployment</th>
+          <th md-column md-order-by="tenant_id">Tenant</th>
           <th md-column>Conduit</th>
         </tr>
       </thead>
       <tbody md-body>
         <tr md-row md-select="network" md-select-id="{{network.id}}" md-auto-select ng-repeat="network in networks.getNetworks() | orderBy: myOrder">
-          <td md-cell><a ng-href='#/networks/{{network.id}}'>{{network.name}}</a></td>
+          <td md-cell><a ng-href="#/networks/{{network.id}}">{{network.name}}</a></td>
           <td md-cell>{{network.description}}</td>
           <td md-cell>{{network.category}}</td>
           <td md-cell>{{network.group}}</td>
-          <td md-cell><a ng-href='#/deployments/{{network.deployment_id}}'>{{_deployments[network.deployment_id].name}}</a></td>
-          <td md-cell><a ng-href='#/tenants/{{_tenants[network.tenant_id].uuid}}'>{{_tenants[network.tenant_id].name}}</a></td>
+          <td md-cell><a ng-href="#/deployments/{{network.deployment_id}}">{{_deployments[network.deployment_id].name}}</a></td>
+          <td md-cell><a ng-href="#/tenants/{{_tenants[network.tenant_id].uuid}}">{{_tenants[network.tenant_id].name}}</a></td>
           <td md-cell>{{network.conduit}}</td>
         </tr>
       </tbody>
@@ -82,7 +82,7 @@
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='networks.showAddNetworkDialog()'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="networks.showAddNetworkDialog()">
     <md-icon>add</md-icon>
     <md-tooltip>Add Network</md-tooltip>
   </md-button>

--- a/views/networks_singular.html
+++ b/views/networks_singular.html
@@ -5,25 +5,25 @@
         {{network.name}}
       </span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='startEditing()' ng-hide='editing'>
+      <md-button class="md-icon-button" ng-click="startEditing()" ng-hide="editing">
         <md-icon>edit</md-icon>
         <md-tooltip>
           Edit
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='saveNetwork()' ng-show='editing'>
+      <md-button class="md-icon-button" ng-click="saveNetwork()" ng-show="editing">
         <md-icon>save</md-icon>
         <md-tooltip>
           Save
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='stopEditing()' ng-show='editing'>
+      <md-button class="md-icon-button" ng-click="stopEditing()" ng-show="editing">
         <md-icon>close</md-icon>
         <md-tooltip>
           Stop Editing
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='delete()'>
+      <md-button class="md-icon-button" ng-click="delete()">
         <md-icon>delete</md-icon>
         <md-tooltip>Delete</md-tooltip>
       </md-button>
@@ -33,7 +33,7 @@
   <md-card-content>
     <table layout-padding>
       <tr>
-        <td class='label'>
+        <td class="label">
           Name
         </td>
         <td>
@@ -41,48 +41,48 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Description
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.description' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.description" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Category
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.category' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.category" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Group
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.group' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.group" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           PBR
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.pbr' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.pbr" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Deployment
         </td>
         <td>
-          <a ng-href='#/deployments/{{network.deployment_id}}'>
+          <a ng-href="#/deployments/{{network.deployment_id}}">
             {{_deployments[network.deployment_id].name}}
           </a>
           <md-menu md-position-mode="target-right target">
             <span>
-              <md-icon style='width: 6px; height: 6px; position: relative; margin-top: -20px;' ng-click="$mdOpenMenu($event)">build</md-icon>
+              <md-icon style="width: 6px; height: 6px; position: relative; margin-top: -20px;" ng-click="$mdOpenMenu($event)">build</md-icon>
             </span>
             <md-menu-content width="4">
               <md-menu-item ng-repeat="deployment in _deployments">
@@ -106,16 +106,16 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Tenant
         </td>
         <td>
-          <a ng-href='#/tenants/{{_tenants[network.tenant_id].uuid}}'>
+          <a ng-href="#/tenants/{{_tenants[network.tenant_id].uuid}}">
             {{_tenants[network.tenant_id].name}}
           </a>
           <md-menu md-position-mode="target-right target">
             <span>
-              <md-icon style='width: 6px; height: 6px; position: relative; margin-top: -20px;' ng-click="$mdOpenMenu($event)">build</md-icon>
+              <md-icon style="width: 6px; height: 6px; position: relative; margin-top: -20px;" ng-click="$mdOpenMenu($event)">build</md-icon>
             </span>
             <md-menu-content width="4">
               <md-menu-item ng-repeat="tenant in _tenantsInOrder">
@@ -131,53 +131,53 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Conduits
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.conduit' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.conduit" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           VLAN
         </td>
-        <td layout='row'>
-          <md-switch ng-model="network.use_vlan" aria-label="Switch" ng-disabled='!editing' style='margin: 0;'>
+        <td layout="row">
+          <md-switch ng-model="network.use_vlan" aria-label="Switch" ng-disabled="!editing" style="margin: 0;">
             <md-tooltip>
               Enable/Disable VLAN
             </md-tooltip>
           </md-switch>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.vlan' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.vlan" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           IPv6 Prefix
         </td>
         <td>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.v6prefix' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.v6prefix" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Team
         </td>
-        <td layout='row'>
-          <md-switch ng-model="network.use_team" aria-label="Switch" ng-disabled='!editing' style='margin: 0;'>
+        <td layout="row">
+          <md-switch ng-model="network.use_team" aria-label="Switch" ng-disabled="!editing" style="margin: 0;">
             <md-tooltip>
               Enable/Disable Team
             </md-tooltip>
           </md-switch>
-          <input type='text' class='table-input' ng-readonly="!editing" ng-model='network.team_mode' />
+          <input type="text" class="table-input" ng-readonly="!editing" ng-model="network.team_mode" />
         </td>
       </tr>
       <tr>
-        <td class='label'>
+        <td class="label">
           Bridge
         </td>
-        <td layout='row'>
-          <md-switch ng-model="network.use_bridge" aria-label="Switch" ng-disabled='!editing' style='margin: 0;'>
+        <td layout="row">
+          <md-switch ng-model="network.use_bridge" aria-label="Switch" ng-disabled="!editing" style="margin: 0;">
             <md-tooltip>
               Enable/Disable Bridge
             </md-tooltip>
@@ -193,37 +193,37 @@
     <div class="md-toolbar-tools">
       <span>Ranges</span>
       <span flex></span>
-      <span ng-if='hasRanges == 1'>
+      <span ng-if="hasRanges == 1">
         <md-button
-          class='md-icon-button'
-          ng-click='startEditingRanges()'
-          ng-hide='editingRanges'>
+          class="md-icon-button"
+          ng-click="startEditingRanges()"
+          ng-hide="editingRanges">
           <md-icon>edit</md-icon>
           <md-tooltip>
             Edit
           </md-tooltip>
         </md-button>
         <md-button
-          class='md-icon-button'
-          ng-click='saveNetworkRanges()'
-          ng-show='editingRanges'>
+          class="md-icon-button"
+          ng-click="saveNetworkRanges()"
+          ng-show="editingRanges">
           <md-icon>save</md-icon>
           <md-tooltip>
             Save
           </md-tooltip>
         </md-button>
         <md-button
-          class='md-icon-button'
-          ng-click='stopEditingRanges()'
-          ng-show='editingRanges'>
+          class="md-icon-button"
+          ng-click="stopEditingRanges()"
+          ng-show="editingRanges">
           <md-icon>close</md-icon>
           <md-tooltip>
             Stop Editing
           </md-tooltip>
         </md-button>
         <md-button
-          class='md-icon-button'
-          ng-click='addRange()'>
+          class="md-icon-button"
+          ng-click="addRange()">
           <md-icon>add</md-icon>
           <md-tooltip>
             Add Range
@@ -252,16 +252,16 @@
           <tbody>
             <tr ng-repeat="(id, range) in ranges">
               <td>
-                <input type='text' class='table-input' ng-readonly="!editingRanges" ng-model='range.name' />
+                <input type="text" class="table-input" ng-readonly="!editingRanges" ng-model="range.name" />
               </td>
               <td>
-                <input type='text' class='table-input' ng-readonly="!editingRanges" ng-model='range.first' />
+                <input type="text" class="table-input" ng-readonly="!editingRanges" ng-model="range.first" />
               </td>
               <td>
-                <input type='text' class='table-input' ng-readonly="!editingRanges" ng-model='range.last' />
+                <input type="text" class="table-input" ng-readonly="!editingRanges" ng-model="range.last" />
               </td>
               <td>
-                <md-button class='md-icon-button' ng-click='deleteRange(range.id)'>
+                <md-button class="md-icon-button" ng-click="deleteRange(range.id)">
                   <md-icon>delete</md-icon>
                   <md-tooltip>Delete Range</md-tooltip>
                 </md-button>
@@ -271,7 +271,7 @@
         </table>
       </md-card-content>
     </div>
-    <md-card-content>
+  </md-card-content>
 </md-card>
 
 <md-card>
@@ -279,29 +279,29 @@
     <div class="md-toolbar-tools">
       <span>Router</span>
       <span flex></span>
-      <span ng-if='hasRouter == 1'>
+      <span ng-if="hasRouter == 1">
         <md-button
-          class='md-icon-button'
-          ng-click='startEditingRouter()'
-          ng-hide='editingRouter'>
+          class="md-icon-button"
+          ng-click="startEditingRouter()"
+          ng-hide="editingRouter">
           <md-icon>edit</md-icon>
           <md-tooltip>
             Edit
           </md-tooltip>
         </md-button>
         <md-button
-          class='md-icon-button'
-          ng-click='saveNetworkRouter()'
-          ng-show='editingRouter'>
+          class="md-icon-button"
+          ng-click="saveNetworkRouter()"
+          ng-show="editingRouter">
           <md-icon>save</md-icon>
           <md-tooltip>
             Save
           </md-tooltip>
         </md-button>
         <md-button
-          class='md-icon-button'
-          ng-click='stopEditingRouter()'
-          ng-show='editingRouter'>
+          class="md-icon-button"
+          ng-click="stopEditingRouter()"
+          ng-show="editingRouter">
           <md-icon>close</md-icon>
           <md-tooltip>
             Stop Editing
@@ -323,23 +323,23 @@
       <md-card-content ng-switch-when="1">
         <table layout-padding>
           <tr>
-            <td class='label'>
+            <td class="label">
               Address
             </td>
             <td>
-              <input type='text' class='table-input' ng-readonly="!editingRouter" ng-model='router.address' />
+              <input type="text" class="table-input" ng-readonly="!editingRouter" ng-model="router.address" />
             </td>
           </tr>
           <tr>
-            <td class='label'>
+            <td class="label">
               Pref
             </td>
             <td>
-              <input type='text' class='table-input' ng-readonly="!editingRouter" ng-model='router.pref' />
+              <input type="text" class="table-input" ng-readonly="!editingRouter" ng-model="router.pref" />
             </td>
           </tr>
         </table>
       </md-card-content>
     </div>
-    <md-card-content>
+  </md-card-content>
 </md-card>

--- a/views/node_roles.html
+++ b/views/node_roles.html
@@ -1,18 +1,18 @@
 <md-card>
-  <md-toolbar class="md-table-toolbar md-default" ng-hide='node_roles.selected.length'>
+  <md-toolbar class="md-table-toolbar md-default" ng-hide="node_roles.selected.length">
     <div class="md-toolbar-tools">
       <span flex>Node Roles ({{getNodeRoles().length}})</span>
-      <md-button class='md-icon-button' ng-click='retrySelected(getNodeRoles())'>
+      <md-button class="md-icon-button" ng-click="retrySelected(getNodeRoles())">
         <md-icon>redo</md-icon>
         <md-tooltip>Retry All</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-href='#/roles'>
+      <md-button class="md-icon-button" ng-href="#/roles">
         <md-icon>label_outline</md-icon>
         <md-tooltip md-direction="bottom">
           Roles
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-href='#/deployment_roles'>
+      <md-button class="md-icon-button" ng-href="#/deployment_roles">
         <md-icon>dashboard</md-icon>
         <md-tooltip md-direction="bottom">
           Deployment Roles
@@ -21,15 +21,15 @@
     </div>
   </md-toolbar>
 
-  <md-toolbar class="md-table-toolbar alternate" ng-show='node_roles.selected.length'>
+  <md-toolbar class="md-table-toolbar alternate" ng-show="node_roles.selected.length">
     <div class="md-toolbar-tools">
       <span>{{node_roles.selected.length}} node role{{node_roles.selected.length != 1 && 's' || ''}} selected</span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='retrySelected()'>
+      <md-button class="md-icon-button" ng-click="retrySelected()">
         <md-icon>redo</md-icon>
         <md-tooltip>Retry Selected</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='destroySelected()'>
+      <md-button class="md-icon-button" ng-click="destroySelected()">
         <md-icon>delete</md-icon>
         <md-tooltip>Destroy Node Roles</md-tooltip>
       </md-button>
@@ -37,20 +37,20 @@
   </md-toolbar>
 
   <md-table-container>
-    <table md-table md-row-select ng-model='node_roles.selected'>
+    <table md-table md-row-select ng-model="node_roles.selected">
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='id'>State</th>
-          <th md-column md-order-by='deployment_id'>Deployment</th>
-          <th md-column md-order-by='node_id'>Node</th>
-          <th md-column md-order-by='role_id'>Role</th>
+          <th md-column md-order-by="id">State</th>
+          <th md-column md-order-by="deployment_id">Deployment</th>
+          <th md-column md-order-by="node_id">Node</th>
+          <th md-column md-order-by="role_id">Role</th>
           <th md-column>Node Role</th>
         </tr>
       </thead>
       <tbody md-body swap-md-paint-bg="status_{{role.status}} primary" swap-md-paint-fg="status_{{role.status}} foreground" ng-repeat="role in getNodeRoles() | orderBy: myOrder">
-        <tr md-row md-select='role' md-select-id='{{role.id}}' md-auto-select>
+        <tr md-row md-select="role" md-select-id="{{role.id}}" md-auto-select>
           <td md-cell>
-            <md-icon ng-href='#/node_roles/{{role.id}}'>
+            <md-icon ng-href="#/node_roles/{{role.id}}">
               {{icons[role.status]}}
               <md-tooltip>
                 {{role.status}}
@@ -58,22 +58,22 @@
             </md-icon>
           </td>
           <td md-cell>
-            <a ng-href='#/dash/{{role.deployment_id}}'>
+            <a ng-href="#/dash/{{role.deployment_id}}">
               {{_deployments[role.deployment_id].name}}
             </a>
           </td>
           <td md-cell>
-            <a ng-href='#/nodes/{{role.node_id}}'>
+            <a ng-href="#/nodes/{{role.node_id}}">
               {{_nodes[role.node_id].name}}
             </a>
           </td>
           <td md-cell>
-            <a ng-href='#/roles/{{role.role_id}}'>
+            <a ng-href="#/roles/{{role.role_id}}">
               {{_roles[role.role_id].name}}
             </a>
           </td>
           <td md-cell>
-            <a ng-href='#/node_roles/{{role.id}}'>
+            <a ng-href="#/node_roles/{{role.id}}">
               <md-icon>
                 {{_roles[role.role_id].icon}}
               </md-icon>

--- a/views/node_roles_singular.html
+++ b/views/node_roles_singular.html
@@ -1,37 +1,37 @@
 <md-card>
-  <md-toolbar class="md-default" md-theme='status_{{node_role.status}}' ng-style="style">
+  <md-toolbar class="md-default" md-theme="status_{{node_role.status}}" ng-style="style">
     <div class="md-toolbar-tools">
       <span>
-        <md-icon class='md-primary'>
+        <md-icon class="md-primary">
           {{icons[node_role.status]}}
           <md-tooltip>
             {{node_role.status}}
           </md-tooltip>
         </md-icon>
-        <a ng-href='#/deployments/{{node_role.deployment_id}}'  swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-href="#/deployments/{{node_role.deployment_id}}" swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_deployments[node_role.deployment_id].name}}
         </a>
-        <a ng-hide=service ng-href='#/nodes/{{node_role.node_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-hide="service" ng-href="#/nodes/{{node_role.node_id}}" swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_nodes[node_role.node_id].name}}
         </a>
-        <em ng-show=service>Service Role</em>
-        <md-icon class='md-primary'>
+        <em ng-show="service">Service Role</em>
+        <md-icon class="md-primary">
           {{_roles[node_role.role_id].icon}}
         </md-icon>
-        <a ng-href='#/roles/{{node_role.role_id}}' swap-md-paint-fg="status_{{node_role.status}} foreground">
+        <a ng-href="#/roles/{{node_role.role_id}}" swap-md-paint-fg="status_{{node_role.status}} foreground">
           {{_roles[node_role.role_id].name}}
         </a>
       </span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='commit()' ng-show='node_role.state == 4' >
+      <md-button class="md-icon-button" ng-click="commit()" ng-show="node_role.state == 4" >
         <md-icon>save</md-icon>
         <md-tooltip>Commit</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='retry()' ng-show='node_role.state != 4' >
+      <md-button class="md-icon-button" ng-click="retry()" ng-show="node_role.state != 4" >
         <md-icon>redo</md-icon>
         <md-tooltip>Retry</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='destroy()'>
+      <md-button class="md-icon-button" ng-click="destroy()">
         <md-icon>delete</md-icon>
         <md-tooltip>Destroy</md-tooltip>
       </md-button>
@@ -39,8 +39,8 @@
 
   </md-toolbar>
 
-  <md-toolbar ng-if='top < 0'>
-    <div class='md-toolbar-tools'>
+  <md-toolbar ng-if="top < 0">
+    <div class="md-toolbar-tools">
       <h2>Node Role</h2>
     </div>
   </md-toolbar>
@@ -54,14 +54,14 @@
   </div>
   <div class="md-toolbar-tools">
     <span flex>
-        <md-icon class='md-icon-button'>dns
+        <md-icon class="md-icon-button">dns
           <md-tooltip>Node Role</md-tooltip>
         </md-icon>
         Node Local Attributes
     </span>
     <span>
-      <a ng-if='deployment_role_id>0' ng-href='#/deployment_roles/{{deployment_role_id}}'>Deployment Scope Attributes
-        <md-icon class='md-icon-button'>dashboard
+      <a ng-if="deployment_role_id>0" ng-href="#/deployment_roles/{{deployment_role_id}}">Deployment Scope Attributes
+        <md-icon class="md-icon-button">dashboard
           <md-tooltip>Deployment Role</md-tooltip>
         </md-icon>
       </a>
@@ -73,13 +73,13 @@
 
 <!-- Run Log -->
 <md-card>
-  <md-toolbar class="md-table-toolbar md-default" id='runlog'>
+  <md-toolbar class="md-table-toolbar md-default" id="runlog">
     <div class="md-toolbar-tools">
       <h2 flex>Run Log</h2>
-      <span class='pull-right' ng-if="node_role.state!=0">
-        Refresh <input ng-model='pollLog' min=1 max=30 type='number' ng-change='changeRate(pollLog)'/> seconds
+      <span class="pull-right" ng-if="node_role.state!=0">
+        Refresh <input ng-model="pollLog" min=1 max=30 type="number" ng-change="changeRate(pollLog)"/> seconds
       </span>
-      <md-button clipboard class='md-icon-button' supported='supported' text="runlog" on-copied='onCopy(true)' on-error='onCopy(false, err)'>
+      <md-button clipboard class="md-icon-button" supported="supported" text="runlog" on-copied="onCopy(true)" on-error="onCopy(false, err)">
         <md-icon>
           content_paste
         </md-icon>
@@ -90,6 +90,6 @@
     </div>
   </md-toolbar>
   <md-card-content>
-    <pre class='runlog'>{{runlog}}</pre>
+    <pre class="runlog">{{runlog}}</pre>
   </md-card-content>
 </md-card>

--- a/views/nodes.html
+++ b/views/nodes.html
@@ -1,25 +1,25 @@
 <md-card>
-  <md-toolbar class="md-table-toolbar md-default" ng-hide='nodes.selected.length'>
+  <md-toolbar class="md-table-toolbar md-default" ng-hide="nodes.selected.length">
     <div class="md-toolbar-tools">
       <span>Nodes ({{nodes.getNodes().length}})</span>
       <span flex></span>
     </div>
   </md-toolbar>
-  <md-toolbar class="md-table-toolbar alternate" ng-show='nodes.selected.length'>
+  <md-toolbar class="md-table-toolbar alternate" ng-show="nodes.selected.length">
     <div class="md-toolbar-tools">
       <span>{{nodes.selected.length}} node{{nodes.selected.length != 1 && 's' || ''}} selected</span>
       <span flex></span>
-      <md-button class='md-icon-button' ng-click='redeploySelected()'>
+      <md-button class="md-icon-button" ng-click="redeploySelected()">
         <md-icon>low_priority</md-icon>
         <md-tooltip>Redeploy Nodes</md-tooltip>
       </md-button>
       <md-menu md-position-mode="target-right target">
-        <md-button class='md-icon-button' ng-click="$mdOpenMenu($event)">
+        <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
           <md-icon>swap_horiz</md-icon>
           <md-tooltip>Move Nodes</md-tooltip>
         </md-button>
         <md-menu-content width="4">
-          <md-switch ng-model='move_tenant'>
+          <md-switch ng-model="move_tenant">
             Move Reassigns Tenant?
           </md-switch>
           <md-menu-item ng-repeat="deployment in _deployments">
@@ -33,7 +33,7 @@
         </md-menu-content>
       </md-menu>
       <md-menu md-position-mode="target-right target">
-        <md-button class='md-icon-button' ng-click="$mdOpenMenu($event)">
+        <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
           <md-icon>group</md-icon>
           <md-tooltip>Change Node Tenant</md-tooltip>
         </md-button>
@@ -49,7 +49,7 @@
         </md-menu-content>
       </md-menu>
 
-      <md-button class='md-icon-button' ng-click='nodes.deleteSelected()'>
+      <md-button class="md-icon-button" ng-click="nodes.deleteSelected()">
         <md-icon>delete</md-icon>
         <md-tooltip>Delete Nodes</md-tooltip>
       </md-button>
@@ -60,13 +60,13 @@
     <table md-table md-row-select ng-model="nodes.selected">
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='state'>State</th>
-          <th md-column md-order-by='name'>Name</th>
-          <th md-column md-order-by='address'>Address</th>
+          <th md-column md-order-by="state">State</th>
+          <th md-column md-order-by="name">Name</th>
+          <th md-column md-order-by="address">Address</th>
           <th md-column>Description</th>
-          <th md-column md-order-by='provider_id'>Provider</th>
-          <th md-column md-order-by='deployment_id'>Deployment</th>
-          <th md-column md-order-by='tenant_id'>Tenant</th>
+          <th md-column md-order-by="provider_id">Provider</th>
+          <th md-column md-order-by="deployment_id">Deployment</th>
+          <th md-column md-order-by="tenant_id">Tenant</th>
         </tr>
       </thead>
       <tbody md-body swap-md-paint-bg="status_{{ api.getNodeStatus(node) }} primary" swap-md-paint-fg="status_{{ api.getNodeStatus(node) }} foreground" ng-repeat="node in nodes.getNodes() | orderBy: myOrder">
@@ -80,19 +80,19 @@
             </md-tooltip>
           </td>
 
-          <td md-cell><a ng-href='#/nodes/{{node.id}}'>{{node.name}}</a></td>
+          <td md-cell><a ng-href="#/nodes/{{node.id}}">{{node.name}}</a></td>
           <td md-cell>
             <a target="_new" ng-href="https://{{node.address.slice(0,-3)}}">{{node.address}}</a>
           </td>
           <td md-cell>{{node.description}}</td>
-          <td md-cell><a ng-href='#/providers/{{node.provider_id}}'>{{_providers[node.provider_id].name}}</a></td>
+          <td md-cell><a ng-href="#/providers/{{node.provider_id}}">{{_providers[node.provider_id].name}}</a></td>
           <td md-cell>
-            <a ng-href='#/deployments/{{node.deployment_id}}'>
+            <a ng-href="#/deployments/{{node.deployment_id}}">
               {{_deployments[node.deployment_id].name}}
             </a>
           </td>
           <td md-cell>
-            <a ng-href='#/tenants/{{_tenants[node.tenant_id].uuid}}'>
+            <a ng-href="#/tenants/{{_tenants[node.tenant_id].uuid}}">
               {{_tenants[node.tenant_id].name}}
             </a>
           </td>
@@ -104,7 +104,7 @@
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='nodes.showAddNodeDialog()'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="nodes.showAddNodeDialog()">
     <md-icon>add</md-icon>
     <md-tooltip>Add Nodes</md-tooltip>
   </md-button>

--- a/views/nodes_singular.html
+++ b/views/nodes_singular.html
@@ -1,8 +1,8 @@
 <md-card>
-  <md-toolbar class="md-default" md-theme='status_{{ api.getNodeStatus(node) }}'>
+  <md-toolbar class="md-default" md-theme="status_{{ api.getNodeStatus(node) }}">
     <div class="md-toolbar-tools">
       <span>
-        <md-icon class='md-primary'>
+        <md-icon class="md-primary">
           {{api.getNodeIcon(node)}}
           <md-tooltip>
             {{node.available ? '' : 'Reserved'}} {{node.status}}
@@ -12,16 +12,16 @@
       <span flex>
         {{node.name}}
       </span>
-      <md-button ng-repeat="pb in power" aria-label="{{pb}}" class='md-icon-button' ng-click='setPower(pb)'>
+      <md-button ng-repeat="pb in power" aria-label="{{pb}}" class="md-icon-button" ng-click="setPower(pb)">
         <md-icon>{{ powers[pb] || powers["on"] }}</md-icon>
         <md-tooltip>{{ pb }}</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' aria-label="redeploy" ng-click='redeploy()'>
+      <md-button class="md-icon-button" aria-label="redeploy" ng-click="redeploy()">
         <md-icon>low_priority</md-icon>
         <md-tooltip>Redeploy Node</md-tooltip>
       </md-button>
-      <md-menu md-position-mode="target-right target" style='padding: 0;'>
-        <md-button class='md-icon-button' aria-label="bind" ng-click='$mdOpenMenu($event)'>
+      <md-menu md-position-mode="target-right target" style="padding: 0;">
+        <md-button class="md-icon-button" aria-label="bind" ng-click="$mdOpenMenu($event)">
           <md-icon>link</md-icon>
           <md-tooltip>Bind Node Role</md-tooltip>
         </md-button>
@@ -33,7 +33,7 @@
               <md-tooltip>{{ _roles[role.id].description }}</md-tooltip>
             </md-button>
           </md-menu-item>
-          <md-menu-item ng-if='getRoles().length == 0'>
+          <md-menu-item ng-if="getRoles().length == 0">
             <md-button ng-click="$mdCloseMenu($event)">
               <div layout="row" flex>
                 <p flex>No Deployment Roles</p>
@@ -44,19 +44,19 @@
         </md-menu-content>
       </md-menu>
 
-      <md-button class='md-icon-button' ng-if='node.available' ng-click='reserve(true)'>
+      <md-button class="md-icon-button" ng-if="node.available" ng-click="reserve(true)">
         <md-icon>pause</md-icon>
         <md-tooltip>Reserve Node</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-if='!node.available' ng-click='reserve(false)'>
+      <md-button class="md-icon-button" ng-if="!node.available" ng-click="reserve(false)">
         <md-icon>play_arrow</md-icon>
         <md-tooltip>Release Node</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='nodes.deleteNode()'>
+      <md-button class="md-icon-button" ng-click="nodes.deleteNode()">
         <md-icon>delete</md-icon>
         <md-tooltip>Delete Node</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='nodes.showEditNodeDialog($event, node)'>
+      <md-button class="md-icon-button" ng-click="nodes.showEditNodeDialog($event, node)">
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Edit Node</md-tooltip>
       </md-button>
@@ -66,18 +66,18 @@
   <md-card-content>
     <table layout-padding>
       <tr>
-        <td class='label'>Description</td>
-        <td>{{ (node.description.length > 0 ? node.description : "[not set]") }}</td>
+        <td class="label">Description</td>
+        <td>{{ node.description.length > 0 ? node.description : "[not set]" }}</td>
       </tr>
       <tr>
-        <td class='label'>Deployment</td>
+        <td class="label">Deployment</td>
         <td>
-          <a ng-href='#/deployments/{{node.deployment_id}}'>
+          <a ng-href="#/deployments/{{node.deployment_id}}">
             {{_deployments[node.deployment_id].name}}
           </a>
           <md-menu md-position-mode="target-right target">
             <span>
-              <md-icon style='width: 6px; height: 6px; position: relative; margin-top: -20px;' ng-click="$mdOpenMenu($event)">build</md-icon>
+              <md-icon style="width: 6px; height: 6px; position: relative; margin-top: -20px;" ng-click="$mdOpenMenu($event)">build</md-icon>
             </span>
             <md-menu-content width="4">
               <md-menu-item ng-repeat="deployment in _deployments">
@@ -93,14 +93,14 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>Tenant</td>
+        <td class="label">Tenant</td>
         <td>
-          <a ng-href='#/tenants/{{_tenants[node.tenant_id].uuid}}'>
+          <a ng-href="#/tenants/{{_tenants[node.tenant_id].uuid}}">
             {{_tenants[node.tenant_id].name}}
           </a>
           <md-menu md-position-mode="target-right target">
             <span>
-              <md-icon style='width: 6px; height: 6px; position: relative; margin-top: -20px;' ng-click="$mdOpenMenu($event)">build</md-icon>
+              <md-icon style="width: 6px; height: 6px; position: relative; margin-top: -20px;" ng-click="$mdOpenMenu($event)">build</md-icon>
             </span>
             <md-menu-content width="4">
               <md-menu-item ng-repeat="tenant in _tenantsInOrder">
@@ -116,7 +116,7 @@
         </td>
       </tr>
       <tr>
-        <td class='label'>Boot Environment</td>
+        <td class="label">Boot Environment</td>
         <td>
           <div ng-if="showProvisioner">
             <a ng-href="#/provisioner/bootenvs/{{node.bootenv}}">{{node.bootenv}}</a>
@@ -126,38 +126,38 @@
           </span>
         </td>
       </tr>
-      <tr ng-if='showProvisioner'>
-        <td class='label'>Machine</td>
+      <tr ng-if="showProvisioner">
+        <td class="label">Machine</td>
         <td>
           <a ng-href="#/provisioner/machines/{{node.uuid}}">{{node.uuid}}</a>
         </td>
       </tr>
       <tr>
-        <td class='label'>Address</td>
+        <td class="label">Address</td>
         <td>
           <a target="_new" ng-href="https://{{node.address.slice(0,-3)}}">{{node.address}}</a>
         </td>
       </tr>
       <tr ng-if="bmc != null">
-        <td class='label'>BMC</td>
+        <td class="label">BMC</td>
         <td>
           <a target="_new" ng-href="https://{{ bmc }}">{{bmc}}</a>
         </td>
       </tr>
       <tr>
-        <td class='label'>Status</td>
+        <td class="label">Status</td>
         <td>
           {{node.reserved ? 'Reserved' : ''}} {{node.alive ? 'On' : 'Off'}} {{states[node.state]}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Provider</td>
+        <td class="label">Provider</td>
         <td>
-          <a ng-href='#/providers/{{node.provider_id}}'>{{_providers[node.provider_id].name}}</a>
+          <a ng-href="#/providers/{{node.provider_id}}">{{_providers[node.provider_id].name}}</a>
         </td>
       </tr>
       <tr>
-        <td class='label'><a ng-href='#/profiles'>Profile(s)</a></td>
+        <td class="label"><a ng-href="#/profiles">Profile(s)</a></td>
         <td>
           <span ng-repeat="p in node.profiles | orderBy: p">
             {{p}}{{ $last ? '' : ", "}}
@@ -168,13 +168,13 @@
 
     <!-- Show Networks ONLY FOR METAL PROVIDER -->
     <div ng-show="nics != {}">
-      <span class='label'>
+      <span class="label">
         <md-icon>swap_horiz</md-icon>
         Network Interfaces
       </span>
       <ul>
         <li ng-repeat="network in nics | orderBy: _networks[network[0].network_id].name">
-          <a title='{{_networks[network[0].network_id].description}}' href='#/networks/{{network[0].network_id}}'>{{_networks[network[0].network_id].name}}</a>:
+          <a title="{{_networks[network[0].network_id].description}}" href="#/networks/{{network[0].network_id}}">{{_networks[network[0].network_id].name}}</a>:
           <span ng-repeat="nic in network | orderBy: _network_ranges[nic.network_range_id].name">
             {{ _network_ranges[nic.network_range_id].name }}
             <a target="_new" href="https://{{nic.address}}">{{nic.address}}</a>
@@ -196,7 +196,7 @@
   </md-toolbar>
   <md-card-content>
     <span ng-repeat="role in _node_roles | from:'node':node | orderBy: role.cohort()">
-      <md-button class="md-fab md-primary" aria-label="role" md-theme="status_{{role.status}}" ng-href='#/node_roles/{{role.id}}'>
+      <md-button class="md-fab md-primary" aria-label="role" md-theme="status_{{role.status}}" ng-href="#/node_roles/{{role.id}}">
         <md-tooltip md-direction="bottom">{{_roles[role.role_id].name}}</md-tooltip>
         <md-icon>{{_roles[role.role_id].icon}}</md-icon>
       </md-button>

--- a/views/profiles.html
+++ b/views/profiles.html
@@ -1,4 +1,4 @@
-<md-card ng-repeat='profile in _profiles'>
+<md-card ng-repeat="profile in _profiles">
   <md-toolbar class="md-default" ng-click="expand[profile.name]=!expand[profile.name]">
     <div class="md-toolbar-tools">
       <span flex>
@@ -13,7 +13,7 @@
     </div>
   </md-toolbar>
 
-  <div ng-slide-down='expand[profile.name]' lazy-render duration='0.5'>
+  <div ng-slide-down="expand[profile.name]" lazy-render duration="0.5">
     <md-card-content>
       <md-toolbar class="md-table-toolbar md-default">
         <div class="md-toolbar-tools">
@@ -24,17 +24,16 @@
         <table md-table>
           <thead md-head md-order="valueOrder">
             <tr md-row>
-              <th md-column md-order-by='name'>Name</th>
-              <th md-column md-order-by='value'>Value</th>
+              <th md-column md-order-by="name">Name</th>
+              <th md-column md-order-by="value">Value</th>
             </tr>
           </thead>
           <tbody md-body>
-            <tr md-row ng-repeat='(key, value) in profile.values | orderBy: valueOrder'>
+            <tr md-row ng-repeat="(key, value) in profile.values | orderBy: valueOrder">
               <td md-cell>
                 {{key}}
               </td>
               <td md-cell>{{value}}</td>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -42,14 +41,14 @@
     </md-card-content>
 
     <md-card-actions layout="row" layout-align="start center">
-      <md-button class='md-icon-button' ng-click='createProfilePrompt($event, profile)'>
+      <md-button class="md-icon-button" ng-click="createProfilePrompt($event, profile)">
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Edit</md-tooltip>
       </md-button>
 
       <!-- Right side of toolbar -->
-      <md-card-icon-actions layout-align='end center'>
-        <md-button class='md-icon-button' ng-click='deleteProfile(profile.name)'>
+      <md-card-icon-actions layout-align="end center">
+        <md-button class="md-icon-button" ng-click="deleteProfile(profile.name)">
           <md-icon>delete</md-icon>
           <md-tooltip>Destroy</md-tooltip>
         </md-button>
@@ -61,7 +60,7 @@
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createProfilePrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createProfilePrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Profile</md-tooltip>
   </md-button>

--- a/views/provider.html
+++ b/views/provider.html
@@ -3,31 +3,31 @@ provider view
 -->
 
 <!-- Specific provider view -->
-<div ng-if='provider'>
+<div ng-if="provider">
   <md-card>
     <md-toolbar class="md-table-toolbar md-default">
       <div class="md-toolbar-tools">
         <span>{{provider.type}} {{provider.name}}</span>
         <span flex></span>
-        <md-button class='md-icon-button' ng-click='startEditing()' ng-hide='editing'>
+        <md-button class="md-icon-button" ng-click="startEditing()" ng-hide="editing">
           <md-icon>edit</md-icon>
           <md-tooltip>
             Edit
           </md-tooltip>
         </md-button>
-        <md-button class='md-icon-button' ng-click='saveProvider()' ng-show='editing'>
+        <md-button class="md-icon-button" ng-click="saveProvider()" ng-show="editing">
           <md-icon>save</md-icon>
           <md-tooltip>
             Save
           </md-tooltip>
         </md-button>
-        <md-button class='md-icon-button' ng-click='stopEditing()' ng-show='editing'>
+        <md-button class="md-icon-button" ng-click="stopEditing()" ng-show="editing">
           <md-icon>close</md-icon>
           <md-tooltip>
             Stop Editing
           </md-tooltip>
         </md-button>
-        <md-button class='md-icon-button' ng-click='deleteProvider(provider)'>
+        <md-button class="md-icon-button" ng-click="deleteProvider(provider)">
           <md-icon>delete</md-icon>
           <md-tooltip>
             Delete Provider
@@ -40,70 +40,70 @@ provider view
     <md-content layout-padding>
       <table>
         <tr>
-          <td class='label'>
+          <td class="label">
             Provider
           </td>
           <td>
-            <input type='text' ng-minlength='1' ng-required=true ng-readonly="!editing" class='table-input' ng-model='provider.name' />
+            <input type="text" ng-minlength="1" ng-required="true" ng-readonly="!editing" class="table-input" ng-model="provider.name" />
           </td>
         </tr>
         <tr>
-          <td class='label'>
+          <td class="label">
             Tenant
           </td>
           <td>
-            <md-input-container class='md-block'>
-              <md-select ng-model="provider.tenant_id" aria-label="tenant select"  ng-if='editing'>
+            <md-input-container class="md-block">
+              <md-select ng-model="provider.tenant_id" aria-label="tenant select"  ng-if="editing">
                 <md-option ng-repeat="(tennant_id, t) in _tenants" ng-value="tennant_id">
                   {{t.name}}
                 </md-option>
               </md-select>
-              <span ng-if='!editing'>{{_tenants[provider.tenant_id].name}}</span>
+              <span ng-if="!editing">{{_tenants[provider.tenant_id].name}}</span>
             </md-input-container>
           </td>
         </tr>
         <tr>
-          <td class='label'>
+          <td class="label">
             Description
           </td>
           <td>
-            <input type='text' ng-readonly="!editing" class='table-input' ng-model='provider.description' />
+            <input type="text" ng-readonly="!editing" class="table-input" ng-model="provider.description" />
           </td>
         </tr>
-        <tbody ng-repeat='(name,options) in providerTemplates[provider.type]' ng-if='options' ng-switch='options.type'>
-          <tr ng-switch-when='text'>
-            <td class='label'>
+        <tbody ng-repeat="(name,options) in providerTemplates[provider.type]" ng-if="options" ng-switch="options.type">
+          <tr ng-switch-when="text">
+            <td class="label">
               {{options.name}}
             </td>
             <td>
-              <input type='text' class='table-input' ng-readonly="!editing" ng-model='provider.auth_details[name]' ng-value='options.default' />
+              <input type="text" class="table-input" ng-readonly="!editing" ng-model="provider.auth_details[name]" ng-value="options.default" />
             </td>
           </tr>
 
-          <tr ng-switch-when='password'>
-            <td class='label'>
+          <tr ng-switch-when="password">
+            <td class="label">
               {{options.name}}
             </td>
             <td>
-              <input type='password' class='table-input' ng-readonly="!editing" ng-model='provider.auth_details[name]' ng-value='options.default' />
+              <input type="password" class="table-input" ng-readonly="!editing" ng-model="provider.auth_details[name]" ng-value="options.default" />
             </td>
           </tr>
 
-          <tr ng-switch-when='img'>
+          <tr ng-switch-when="img">
             <td></td>
             <td>
-              <a ng-href='{{options.href}}' target="_blank">
-                <img ng-src='{{options.src}}' style='height: 100px; width: auto;'></a>
+              <a ng-href="{{options.href}}" target="_blank">
+                <img ng-src="{{options.src}}" style="height: 100px; width: auto;">
               </a>
             </td>
           </tr>
 
-          <tr ng-switch-when='json_key'>
-            <td class='label'>
+          <tr ng-switch-when="json_key">
+            <td class="label">
               {{options.name}}
             </td>
             <td>
-              <textarea json-text class='table-input' ng-readonly="!editing" style='font-family: monospace;' ng-model='provider.auth_details[name]'>
+              <textarea json-text class="table-input" ng-readonly="!editing" style="font-family: monospace;" ng-model="provider.auth_details[name]">
               </textarea>
             </td>
           </tr>
@@ -135,7 +135,7 @@ provider view
   </md-card>
 </div>
 <!-- Providers list view -->
-<md-card ng-if='!provider' layout='column'>
+<md-card ng-if="!provider" layout="column">
   <md-toolbar class="md-table-toolbar md-default">
     <div class="md-toolbar-tools">
       <span>Providers</span>
@@ -149,18 +149,18 @@ provider view
     <table md-table>
       <thead md-head md-order="myOrder">
         <tr md-row>
-          <th md-column md-order-by='name'>Name</th>
-          <th md-column md-order-by='type'>Type</th>
+          <th md-column md-order-by="name">Name</th>
+          <th md-column md-order-by="type">Type</th>
           <th md-column>Description</th>
-          <th md-column md-order-by='tenant_id'>Tenant</th>
+          <th md-column md-order-by="tenant_id">Tenant</th>
         </tr>
       </thead>
       <tbody md-body>
         <tr md-row ng-repeat="provider in providers.getProviders() | orderBy: myOrder | has:'type'">
-          <td md-cell><a ng-href='#/providers/{{provider.id}}'>{{provider.name}}</a></td>
+          <td md-cell><a ng-href="#/providers/{{provider.id}}">{{provider.name}}</a></td>
           <td md-cell>{{provider.type}}</td>
           <td md-cell>{{provider.description}}</td>
-          <td md-cell><a ng-href='#/tenants/{{_tenants[provider.tenant_id].uuid}}'>{{_tenants[provider.tenant_id].name}}</a></td>
+          <td md-cell><a ng-href="#/tenants/{{_tenants[provider.tenant_id].uuid}}">{{_tenants[provider.tenant_id].name}}</a></td>
         </tr>
       </tbody>
     </table>
@@ -171,8 +171,8 @@ provider view
 <!-- Floating action button at the bottom right of the screen -->
 <div>
   <!-- Add Provider FAB -->
-  <md-menu md-position-mode="target-right target" style='padding: 0;' ng-if='!provider'>
-    <md-button class="md-fab md-accent md-fab-bottom-right" ng-click='$mdOpenMenu($event)'>
+  <md-menu md-position-mode="target-right target" style="padding: 0;" ng-if="!provider">
+    <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="$mdOpenMenu($event)">
       <md-icon>add</md-icon>
       <md-tooltip>
         Add Provider
@@ -199,7 +199,7 @@ provider view
   </md-menu>
 
   <!-- Add Node FAB -->
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='showAddNodeDialog()' ng-if='provider && !(provider.name == "metal" || provider.name == "phantom")'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="showAddNodeDialog()" ng-if="provider && !(provider.name == 'metal' || provider.name == 'phantom')">
     <md-icon>add</md-icon>
     <md-tooltip>
       Add Node

--- a/views/provisioner_bootenvs.html
+++ b/views/provisioner_bootenvs.html
@@ -13,94 +13,94 @@
     </div>
   </md-toolbar>
 
-  <div ng-slide-down='expand[env.Name]' lazy-render duration='0.5'>
+  <div ng-slide-down="expand[env.Name]" lazy-render duration="0.5">
     <md-card-content>
       <table layout-padding>
         <tr ng-hide="{{env.Available}}">
-          <td class='label'>Errors</td>
+          <td class="label">Errors</td>
           <td>
-            <md-chips ng-model='env.Errors' readonly='true'>
-              <md-chip-template style='font-family: monospace;'>
+            <md-chips ng-model="env.Errors" readonly="true">
+              <md-chip-template style="font-family: monospace;">
                 {{$chip}}
               </md-chip-template>
             </md-chips>
           </td>
         </tr>
         <tr>
-          <td class='label' style='min-width: 150px;'>OS Name</td>
+          <td class="label" style="min-width: 150px;">OS Name</td>
           <td>
             {{env.OS.Name}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS Family</td>
+          <td class="label">OS Family</td>
           <td>
             {{env.OS.Family}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS Codename</td>
+          <td class="label">OS Codename</td>
           <td>
             {{env.OS.Codename}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS Version</td>
+          <td class="label">OS Version</td>
           <td>
             {{env.OS.Version}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS ISO File</td>
+          <td class="label">OS ISO File</td>
           <td>
             {{env.OS.IsoFile}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS ISO SHA256</td>
+          <td class="label">OS ISO SHA256</td>
           <td>
             {{env.OS.IsoSha256}}
           </td>
         </tr>
         <tr>
-          <td class='label'>OS ISO Url</td>
+          <td class="label">OS ISO Url</td>
           <td>
             <a ng-href="{{env.OS.IsoUrl}}">{{env.OS.IsoUrl}}</a>
           </td>
         </tr>
         <tr>
-          <td class='label'>OS Available</td>
+          <td class="label">OS Available</td>
           <td>
             {{env.Available}}
           </td>
         </tr>
         <tr>
-          <td class='label'>Kernel</td>
+          <td class="label">Kernel</td>
           <td>
             {{env.Kernel}}
           </td>
         </tr>
         <tr>
-          <td class='label'>Initrds</td>
+          <td class="label">Initrds</td>
           <td>
-            <md-chips ng-model='env.Initrds' readonly='true'>
-              <md-chip-template style='font-family: monospace;'>
+            <md-chips ng-model="env.Initrds" readonly="true">
+              <md-chip-template style="font-family: monospace;">
                 {{$chip}}
               </md-chip-template>
             </md-chips>
           </td>
         </tr>
         <tr>
-          <td class='label'>Boot Params</td>
+          <td class="label">Boot Params</td>
           <td>
             <code>{{env.BootParams}}</code>
           </td>
         </tr>
         <tr>
-          <td class='label'>Required Params</td>
+          <td class="label">Required Params</td>
           <td>
-            <md-chips ng-model='env.RequiredParams' readonly='true'>
-              <md-chip-template style='font-family: monospace;'>
+            <md-chips ng-model="env.RequiredParams" readonly="true">
+              <md-chip-template style="font-family: monospace;">
                 {{$chip}}
               </md-chip-template>
             </md-chips>
@@ -117,13 +117,13 @@
         <table md-table>
           <thead md-head md-order="templateOrder">
             <tr md-row>
-              <th md-column md-order-by='Name'>Name</th>
-              <th md-column md-order-by='Path'>Path</th>
-              <th md-column md-order-by='UUID'>UUID</th>
+              <th md-column md-order-by="Name">Name</th>
+              <th md-column md-order-by="Path">Path</th>
+              <th md-column md-order-by="UUID">UUID</th>
             </tr>
           </thead>
           <tbody md-body>
-            <tr md-row ng-repeat='template in env.Templates | orderBy: templateOrder'>
+            <tr md-row ng-repeat="template in env.Templates | orderBy: templateOrder">
               <td md-cell>
                 {{template.Name}}
               </td>
@@ -133,7 +133,6 @@
                   {{template.UUID}}
                 </a>
               </td>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -141,14 +140,14 @@
     </md-card-content>
 
     <md-card-actions layout="row" layout-align="start center">
-      <md-button class='md-icon-button' ng-click='createBootEnvPrompt($event, env)'>
+      <md-button class="md-icon-button" ng-click="createBootEnvPrompt($event, env)">
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Edit</md-tooltip>
       </md-button>
 
       <!-- Right side of toolbar -->
-      <md-card-icon-actions layout-align='end center'>
-        <md-button class='md-icon-button' ng-click='deleteBootEnv(env.Name)'>
+      <md-card-icon-actions layout-align="end center">
+        <md-button class="md-icon-button" ng-click="deleteBootEnv(env.Name)">
           <md-icon>delete</md-icon>
           <md-tooltip>Destroy</md-tooltip>
         </md-button>
@@ -160,7 +159,7 @@
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createBootEnvPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createBootEnvPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Boot Environment</md-tooltip>
   </md-button>

--- a/views/provisioner_machines.html
+++ b/views/provisioner_machines.html
@@ -2,12 +2,12 @@
 provisioner machines view
 -->
 <div>
-  <md-card ng-repeat='machine in _provisioner.machines' flex='100'>
+  <md-card ng-repeat="machine in _provisioner.machines" flex="100">
 
-    <md-toolbar md-theme='status_{{states[nodeMap[machine.Uuid].state]}}' ng-click="expand[machine.Uuid]=!expand[machine.Uuid]" md-ink-ripple>
-      <div class="md-toolbar-tools" display='row'>
+    <md-toolbar md-theme="status_{{states[nodeMap[machine.Uuid].state]}}" ng-click="expand[machine.Uuid]=!expand[machine.Uuid]" md-ink-ripple>
+      <div class="md-toolbar-tools" display="row">
         <span>
-          <md-icon ng-show='nodeMap[machine.Uuid]'>
+          <md-icon ng-show="nodeMap[machine.Uuid]">
             {{icons[states[nodeMap[machine.Uuid].state]]}}
             <md-tooltip>
               {{states[nodeMap[machine.Uuid].state]}}
@@ -43,25 +43,25 @@ provisioner machines view
     <div ng-slide-down="expand[machine.Uuid]" lazy-render duration="0.25">
       <md-card-content>
         <table layout-padding>
-          <tr ng-if='nodeMap[machine.Uuid]'>
-            <td class='label'>Node</td>
+          <tr ng-if="nodeMap[machine.Uuid]">
+            <td class="label">Node</td>
             <td>
-              <a href='#/deployments/{{nodeMap[machine.Uuid].deployment_id}}'>
+              <a href="#/deployments/{{nodeMap[machine.Uuid].deployment_id}}">
                 {{_deployments[nodeMap[machine.Uuid].deployment_id].name}}
               </a>
-              <a href='#/nodes/{{nodeMap[machine.Uuid].id}}'>
+              <a href="#/nodes/{{nodeMap[machine.Uuid].id}}">
                 {{nodeMap[machine.Uuid].name}}
               </a>
             </td>
           </tr>
           <tr>
-            <td class='label'>Address</td>
+            <td class="label">Address</td>
             <td>
               {{machine.Address}}
             </td>
           </tr>
           <tr>
-            <td class='label'>Boot Environment</td>
+            <td class="label">Boot Environment</td>
             <td>
               <a ng-href="#/provisioner/bootenvs/{{machine.BootEnv}}">
                 {{machine.BootEnv}}
@@ -70,9 +70,10 @@ provisioner machines view
           </tr>
         </table>
         <h3>Params</h3>
-        <section layout-padding style='overflow-x: auto;'>
+        <section layout-padding style="overflow-x: auto;">
           <pre>{{machine.Params | json}}</pre>
         </section>
       </md-card-content>
     </div>
+  </md-card>
 </div>

--- a/views/provisioner_templates.html
+++ b/views/provisioner_templates.html
@@ -2,7 +2,7 @@
 provisioner templates view
 -->
 <div>
-  <md-card ng-repeat='template in _provisioner.templates' flex='100'>
+  <md-card ng-repeat="template in _provisioner.templates" flex="100">
 
     <md-toolbar ng-click="expand[template.UUID]=!expand[template.UUID]" md-ink-ripple>
       <div class="md-toolbar-tools">
@@ -18,38 +18,38 @@ provisioner templates view
       </div>
     </md-toolbar>
     <div ng-slide-down="expand[template.UUID]" lazy-render duration="0.25">
-      <section layout-padding style='overflow-x: auto;'>
+      <section layout-padding style="overflow-x: auto;">
         <pre>{{template.Contents}}</pre>
       </section>
 
       <!-- Toolbar with icons -->
       <md-card-actions layout="row" layout-align="start center">
-        <md-button class='md-icon-button' ng-click='createTemplatePrompt($event, template)'>
+        <md-button class="md-icon-button" ng-click="createTemplatePrompt($event, template)">
           <md-icon>mode_edit</md-icon>
           <md-tooltip>Edit</md-tooltip>
         </md-button>
-        <md-button class='md-icon-button' ng-click='selectFile()'>
+        <md-button class="md-icon-button" ng-click="selectFile()">
           <md-icon>file_upload</md-icon>
           <md-tooltip>Upload</md-tooltip>
         </md-button>
-        <input type="file" id="file" name="file" ng-model="selectedFile" onchange='angular.element(this).scope().upload(angular.element(this).scope().template.UUID)' style='opacity: 0;'/>
+        <input type="file" id="file" name="file" ng-model="selectedFile" onchange="angular.element(this).scope().upload(angular.element(this).scope().template.UUID)" style="opacity: 0;"/>
 
 
         <!-- Right side of toolbar -->
-        <md-card-icon-actions layout-align='end center'>
-          <md-button class='md-icon-button' ng-click='deleteTemplate(template.UUID)'>
+        <md-card-icon-actions layout-align="end center">
+          <md-button class="md-icon-button" ng-click="deleteTemplate(template.UUID)">
             <md-icon>delete</md-icon>
             <md-tooltip>Destroy</md-tooltip>
           </md-button>
         </md-card-icon-actions>
       </md-card-actions>
     </div>
-
+  </md-card>
 </div>
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createTemplatePrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createTemplatePrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Template</md-tooltip>
   </md-button>

--- a/views/roles.html
+++ b/views/roles.html
@@ -5,13 +5,13 @@
         <md-icon>label_outline</md-icon>
         Roles ({{getRoles().length}})
       </span>
-      <md-button class='md-icon-button' ng-href='#/node_roles'>
+      <md-button class="md-icon-button" ng-href="#/node_roles">
         <md-icon>dns</md-icon>
         <md-tooltip md-direction="bottom">
           Node Roles
         </md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-href='#/deployment_roles'>
+      <md-button class="md-icon-button" ng-href="#/deployment_roles">
         <md-icon>dashboard</md-icon>
         <md-tooltip md-direction="bottom">
           Deployment Roles
@@ -25,9 +25,9 @@
       <thead md-head md-order="myOrder">
         <tr md-row>
           <th md-column>Role</th>
-          <th md-column md-order-by='name'>Name</th>
-          <th md-column md-order-by='barclamp_id'>Barclamp</th>
-          <th md-column md-order-by='jig_name'>Jig</th>
+          <th md-column md-order-by="name">Name</th>
+          <th md-column md-order-by="barclamp_id">Barclamp</th>
+          <th md-column md-order-by="jig_name">Jig</th>
           <th md-column>Description</th>
           <th md-column>Flags</th>
           <!-- ["library","implicit","bootstrap","discovery","cluster","destructive","abstract"] -->
@@ -38,7 +38,7 @@
       <tbody md-body>
         <tr md-row ng-repeat="role in getRoles() | orderBy: myOrder">
           <td md-cell>
-            <md-button ng-href='#/roles/{{role.id}}' class='md-primary md-fab md-mini'>
+            <md-button ng-href="#/roles/{{role.id}}" class="md-primary md-fab md-mini">
               <md-icon>
                 {{role.icon}}
               </md-icon>
@@ -48,10 +48,10 @@
             </md-button>
           </td>
           <td md-cell>
-            <a ng-href='#/roles/{{role.id}}'>{{role.name}}</a>
+            <a ng-href="#/roles/{{role.id}}">{{role.name}}</a>
           </td>
           <td md-cell>
-            <a ng-href='#/barclamps/{{role.barclamp_id}}'>
+            <a ng-href="#/barclamps/{{role.barclamp_id}}">
             {{_barclamps[role.barclamp_id].name}}
           </a>
           </td>
@@ -62,7 +62,7 @@
             {{role.description}}
           </td>
           <td md-cell>
-            <span ng-repeat="flag in flags" ng-if='role[flag]'>
+            <span ng-repeat="flag in flags" ng-if="role[flag]">
             {{flag}}
             </span>
           </td>

--- a/views/roles_ansible_play.tmpl.html
+++ b/views/roles_ansible_play.tmpl.html
@@ -1,8 +1,8 @@
 <md-toolbar class="md-table-toolbar md-default">
   <div class="md-toolbar-tools">
     <span flex>Ansible Metadata</span>
-    <span class='inset'>
-      <md-button class='md-icon-button' ng-click='saveAnsible($event)'>
+    <span class="inset">
+      <md-button class="md-icon-button" ng-click="saveAnsible($event)">
         <md-icon>save</md-icon>
         <md-tooltip>Save</md-tooltip>
       </md-button>
@@ -12,59 +12,59 @@
 
 <md-card-content>
 
-  <div ng-if='metadata["playbook_src_paths"][role.name] == "metadata"'>
+  <div ng-if="metadata['playbook_src_paths'][role.name] == 'metadata'">
     <table layout-padding>
       <tr>
-        <td class='label'>Playbook File</td>
-        <td><input ng-type='text' ng-model='metadata["playbook_file"]'/></td>
+        <td class="label">Playbook File</td>
+        <td><input ng-type="text" ng-model="metadata['playbook_file']"/></td>
       </tr>
       <tr>
-        <td class='label'>Playbook Path</td>
-        <td><input ng-type='text' ng-model='metadata["playbook_path"]'/></td>
+        <td class="label">Playbook Path</td>
+        <td><input ng-type="text" ng-model="metadata['playbook_path']"/></td>
       </tr>
       <tr>
-        <td class='label'>Playbook Scope</td>
-        <td><input ng-type='text' ng-model='metadata["playbook_scope"]'/></td>
+        <td class="label">Playbook Scope</td>
+        <td><input ng-type="text" ng-model="metadata['playbook_scope']"/></td>
       </tr>
       <tr>
-        <td class='label'>Role Map</td>
+        <td class="label">Role Map</td>
         <td>
-          <span ng-repeat='(key, value) in metadata["role_role_map"] track by key'>
-            <input ng-type='text' ng-model='key'/>
-            <input ng-type='text' ng-model='value'/>
+          <span ng-repeat="(key, value) in metadata['role_role_map'] track by key">
+            <input ng-type="text" ng-model="key"/>
+            <input ng-type="text" ng-model="value"/>
           </span>
         </td>
       </tr>
       <tr>
-        <td class='label'>Playbook Source Paths</td>
+        <td class="label">Playbook Source Paths</td>
         <td>
-          <span ng-repeat='(key, value) in metadata["playbook_src_paths"] track by key'>
-            <input ng-type='text' ng-model='key'/>
-            <input ng-type='text' ng-model='value'/>
+          <span ng-repeat="(key, value) in metadata['playbook_src_paths'] track by key">
+            <input ng-type="text" ng-model="key"/>
+            <input ng-type="text" ng-model="value"/>
           </span>
         </td>
       </tr>
     </table>
 
-    <table layout-padding width='100%'>
+    <table layout-padding width="100%">
       <tr>
-        <th width='15%'>File</th>
+        <th width="15%">File</th>
         <th>File Body</th>
         <td>
-          <md-button class='md-icon-button' ng-click='addFile($index)'>
+          <md-button class="md-icon-button" ng-click="addFile($index)">
             <md-icon>add_circle_outline</md-icon>
             <md-tooltip>Add File {{$index+1}}</md-tooltip>
           </md-button>
         </td>
       </tr >
-      <tr ng-repeat='file in metadata["files"]'>
+      <tr ng-repeat="file in metadata['files']">
         <td>
-          Path: <input ng-type='text' ng-model='file["type"]'/>
-          Name: <input ng-type='text' ng-model='file["name"]'/>
+          Path: <input ng-type="text" ng-model="file['type']"/>
+          Name: <input ng-type="text" ng-model="file['name']"/>
         </td>
-        <td><textarea ng-model='file["body"]' style='width: 100%; font-family: monospace; min-height: 100px;'></textarea></td>
+        <td><textarea ng-model="file['body']" style="width: 100%; font-family: monospace; min-height: 100px;"></textarea></td>
         <td>
-          <md-button class='md-icon-button' ng-click='removeFile($index)'>
+          <md-button class="md-icon-button" ng-click="removeFile($index)">
             <md-icon>clear</md-icon>
             <md-tooltip>Remove File {{$index+1}}</md-tooltip>
           </md-button>
@@ -77,9 +77,9 @@
     <pre> {{ metadata | json }} </pre>
   </div>
 
-  <div ng-if='metadata["playbook_src_paths"][role.name] != "metadata"'>
+  <div ng-if="metadata['playbook_src_paths'][role.name] != 'metadata'">
     <span flex>Ansible Metadata Editor</span>
-    <textarea json-text ng-model='metadata' style='width: 100%; font-family: monospace; min-height: 200px;'></textarea>
+    <textarea json-text ng-model="metadata" style="width: 100%; font-family: monospace; min-height: 200px;"></textarea>
   </div>
 
 </md-card-content>

--- a/views/roles_script.tmpl.html
+++ b/views/roles_script.tmpl.html
@@ -1,12 +1,12 @@
 <md-toolbar class="md-table-toolbar md-default">
   <div class="md-toolbar-tools">
     <span flex>Script Metadata</span>
-    <span class='inset' ng-show="scripts.length">
-      <md-button class='md-icon-button' ng-click='addSection($index)'>
+    <span class="inset" ng-show="scripts.length">
+      <md-button class="md-icon-button" ng-click="addSection($index)">
         <md-icon>add_circle_outline</md-icon>
         <md-tooltip>Add Section {{$index+1}}</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-click='saveScripts($event)'>
+      <md-button class="md-icon-button" ng-click="saveScripts($event)">
         <md-icon>save</md-icon>
         <md-tooltip>Save</md-tooltip>
       </md-button>
@@ -16,14 +16,14 @@
 
 <md-card-content>
   <div ng-repeat="(key, value) in scripts track by key">
-    <md-dialog-content layout='row' id="section_{{key}}" ng-show="scripts[key]">
+    <md-dialog-content layout="row" id="section_{{key}}" ng-show="scripts[key]">
       <span>Section {{ $index+1 }}
-        <md-button class='md-icon-button' ng-click='removeSection($index)'>
+        <md-button class="md-icon-button" ng-click="removeSection($index)">
           <md-icon>clear</md-icon>
           <md-tooltip>Remove Section {{$index+1}}</md-tooltip>
         </md-button>
       </span>
-      <textarea ng-model='scripts[key]' style='width: 100%; font-family: monospace; min-height: 100px;'></textarea>
+      <textarea ng-model="scripts[key]" style="width: 100%; font-family: monospace; min-height: 100px;"></textarea>
     </md-dialog-content>
   </div>
 </md-card-content>

--- a/views/roles_singular.html
+++ b/views/roles_singular.html
@@ -8,7 +8,7 @@
         {{role.name}}
       </span>
       <md-menu md-position-mode="target-right target">
-        <md-button class='md-icon-button' ng-click="$mdOpenMenu($event)">
+        <md-button class="md-icon-button" ng-click="$mdOpenMenu($event)">
           <md-icon>dashboard</md-icon>
           <md-tooltip>Add to Deployment</md-tooltip>
         </md-button>
@@ -23,11 +23,11 @@
           </md-menu-item>
         </md-menu-content>
       </md-menu>
-      <md-button class='md-icon-button' ng-click='retry()'>
+      <md-button class="md-icon-button" ng-click="retry()">
         <md-icon>redo</md-icon>
         <md-tooltip>Retry All Node Roles</md-tooltip>
       </md-button>
-      <md-button class='md-icon-button' ng-href='#/roles'>
+      <md-button class="md-icon-button" ng-href="#/roles">
         <md-icon>label_outline</md-icon>
         <md-tooltip md-direction="bottom">
           Roles
@@ -39,27 +39,27 @@
   <md-card-content>
     <table layout-padding>
       <tr>
-        <td class='label'>Description</td>
+        <td class="label">Description</td>
         <td>
           {{role.description}}
         </td>
       </tr>
       <tr>
-        <td class='label'>Jig</td>
+        <td class="label">Jig</td>
         <td>{{role.jig_name}}</td>
       </tr>
       <tr>
-        <td class='label'>Barclamp</td>
+        <td class="label">Barclamp</td>
         <td>
-          <a ng-href='#/barclamps/{{role.barclamp_id}}'>
+          <a ng-href="#/barclamps/{{role.barclamp_id}}">
             {{_barclamps[role.barclamp_id].name}}
           </a>
         </td>
       </tr>
       <tr>
-        <td class='label'>Flags</td>
+        <td class="label">Flags</td>
         <td>
-          <span ng-repeat="flag in flags" ng-if='role[flag]'>
+          <span ng-repeat="flag in flags" ng-if="role[flag]">
             {{flag}}
           </span>
         </td>
@@ -87,7 +87,7 @@
         <tr>
           <td ng-repeat="(name, group) in relations" ng-show="group.length>0">
             <span ng-repeat="r in group | orderBy: r.cohort">
-              <md-button class="md-fab md-primary" ng-href='#/roles/{{r.id}}'>
+              <md-button class="md-fab md-primary" ng-href="#/roles/{{r.id}}">
                 <md-icon>{{r.icon}}</md-icon>
                 <md-tooltip md-direction="bottom">
                   {{r.name}}: {{r.description}}
@@ -110,7 +110,7 @@
   </md-toolbar>
   <md-card-content>
     <span ng-repeat="node_role in _node_roles | from:'role':role | orderBy: node_role.cohort()">
-      <md-button class="md-fab md-primary" md-theme="status_{{node_role.status}}" ng-href='#/node_roles/{{node_role.id}}'>
+      <md-button class="md-fab md-primary" md-theme="status_{{node_role.status}}" ng-href="#/node_roles/{{node_role.id}}">
         <md-icon>{{icons[node_role.status]}}</md-icon>
         <md-tooltip md-direction="bottom">
           {{_nodes[node_role.node_id].name}}

--- a/views/switches.html
+++ b/views/switches.html
@@ -7,7 +7,7 @@
     </h1>
     <span>{{ sw.switch.description }}</span>
 
-    <table layout-padding border=1>
+    <table layout-padding border="1">
       <tbody>
         <tr align="center">
           <td width="4%" ng-repeat="p in layout">{{p}}</td></tr>
@@ -17,7 +17,7 @@
               <md-tooltip md-direction="bottom">
                 {{node.name}}: {{node.nic}}
               </md-tooltip>
-              <md-icon aria-label='{{ api.getNodeStatus(_nodes[node.id]) }}'>
+              <md-icon aria-label="{{ api.getNodeStatus(_nodes[node.id]) }}">
                 {{ api.getNodeIcon(_nodes[node.id]) }}
               </md-icon>
             </md-button>
@@ -31,7 +31,7 @@
               <md-tooltip md-direction="bottom">
                 {{node.name}}: {{node.nic}}
               </md-tooltip>
-              <md-icon aria-label='{{ api.getNodeStatus(_nodes[node.id]) }}'>
+              <md-icon aria-label="{{ api.getNodeStatus(_nodes[node.id]) }}">
                 {{ api.getNodeIcon(_nodes[node.id]) }}
               </md-icon>
             </md-button>

--- a/views/tenants.html
+++ b/views/tenants.html
@@ -2,15 +2,15 @@
 Tenants view
 -->
 <div layout-padding>
-  <md-card flex='100' ng-style='{"margin-left": tenant.depth+"em"}' style="padding: 0;" ng-repeat="(tenant_id, tenant) in _tenantsInOrder">
+  <md-card flex="100" ng-style="{'margin-left': tenant.depth+'em'}" style="padding: 0;" ng-repeat="(tenant_id, tenant) in _tenantsInOrder">
     <md-toolbar ng-click="expand[tenant.uuid]=!expand[tenant.uuid]" md-ink-ripple>
-      <div class='md-toolbar-tools'>
+      <div class="md-toolbar-tools">
         <h2 flex>
           <md-icon aria-label="Tenant">group</md-icon>
           {{tenant.name}}
         </h2>
         <span>
-          <md-button class='md-icon-button'>
+          <md-button class="md-icon-button">
             <md-icon ng-hide="expand[tenant.uuid]">expand_more</md-icon>
             <md-icon ng-show="expand[tenant.uuid]">expand_less</md-icon>
           </md-button>
@@ -19,10 +19,10 @@ Tenants view
     </md-toolbar>
 
     <div ng-slide-down="expand[tenant.uuid]" lazy-render duration="0.25">
-      <section layout-padding style='overflow-x: auto;'>
+      <section layout-padding style="overflow-x: auto;">
         <table>
           <tr>
-            <td class='label'>
+            <td class="label">
               Description
             </td>
             <td>
@@ -30,12 +30,12 @@ Tenants view
             </td>
           </tr>
           <tr>
-            <td class='label' valign="top">
+            <td class="label" valign="top">
               Users
             </td>
             <td>
-              <md-chips ng-model='tenant.users' readonly='true'>
-                <md-chip-template style='font-family: monospace;' ng-click='setPath("/users/"+$chip.id)'>
+              <md-chips ng-model="tenant.users" readonly="true">
+                <md-chip-template style="font-family: monospace;" ng-click="setPath('/users/'+$chip.id)">
                   {{$chip.username}}
                 </md-chip-template>
               </md-chips>
@@ -44,18 +44,18 @@ Tenants view
         </table>
       </section>
       <md-card-actions layout="row" layout-align="end center">
-        <md-button class='md-icon-button' ng-click='createTenantPrompt($event, tenant)'>
+        <md-button class="md-icon-button" ng-click="createTenantPrompt($event, tenant)">
           <md-icon>mode_edit</md-icon>
           <md-tooltip>Edit</md-tooltip>
         </md-button>
 
         <!-- Right side of toolbar -->
-        <md-card-icon-actions layout-align='end center'>
-          <md-button class='md-icon-button' ng-click='deleteTenant(tenant.name)'>
+        <md-card-icon-actions layout-align="end center">
+          <md-button class="md-icon-button" ng-click="deleteTenant(tenant.name)">
             <md-icon>delete</md-icon>
             <md-tooltip>Destroy</md-tooltip>
           </md-button>
-          <span flex='10'>
+          <span flex="10">
           </span>
         </md-card-icon-actions>
       </md-card-actions>
@@ -65,7 +65,7 @@ Tenants view
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createTenantPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createTenantPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create Tenant</md-tooltip>
   </md-button>

--- a/views/users.html
+++ b/views/users.html
@@ -1,7 +1,7 @@
 <!--
 users view
 -->
-<md-card flex='100' ng-repeat="user in getUserList() | orderBy:'username'">
+<md-card flex="100" ng-repeat="user in getUserList() | orderBy:'username'">
 
   <md-toolbar ng-click="expand[user.id]=!expand[user.id]" md-ink-ripple>
     <div class="md-toolbar-tools">
@@ -13,7 +13,7 @@ users view
         <md-icon aria-label="Tenant">group</md-icon> {{_tenants[user.tenant_id].name || user.tenant_id}}
       </h2>
       <span>
-        <md-button class='md-icon-button'>
+        <md-button class="md-icon-button">
           <md-icon ng-hide="expand[user.id]">expand_more</md-icon>
           <md-icon ng-show="expand[user.id]">expand_less</md-icon>
         </md-button>
@@ -21,10 +21,10 @@ users view
     </div>
   </md-toolbar>
   <div ng-slide-down="expand[user.id]" lazy-render duration="0.25">
-    <section layout-padding style='overflow-x: auto;'>
+    <section layout-padding style="overflow-x: auto;">
       <table>
         <tr>
-          <td class='label'>
+          <td class="label">
             Email
           </td>
           <td>
@@ -32,20 +32,20 @@ users view
           </td>
         </tr>
         <tr>
-          <td class='label'>
+          <td class="label">
             Tenant
           </td>
           <td>
-            <a ng-href='#/tenants/{{_tenants[user.tenant_id].uuid}}'>{{_tenants[user.tenant_id].name || user.tenant_id}}</a>
+            <a ng-href="#/tenants/{{_tenants[user.tenant_id].uuid}}">{{_tenants[user.tenant_id].name || user.tenant_id}}</a>
           </td>
         </tr>
-        <tr ng-repeat='(tenant_id, tenant) in user.caps'>
-          <td class='label' valign="top">
+        <tr ng-repeat="(tenant_id, tenant) in user.caps">
+          <td class="label" valign="top">
             Capabilities ({{_tenants[tenant_id].name || tenant_id}})
           </td>
           <td>
-            <md-chips ng-model='tenant.caps' readonly='true'>
-              <md-chip-template style='font-family: monospace;'>
+            <md-chips ng-model="tenant.caps" readonly="true">
+              <md-chip-template style="font-family: monospace;">
                 {{_capabilities[$chip].name}}
               </md-chip-template>
             </md-chips>
@@ -55,23 +55,23 @@ users view
     </section>
 
     <md-card-actions layout="row" layout-align="end center">
-      <md-button class='md-icon-button' ng-click='createUserPrompt($event, user)'>
+      <md-button class="md-icon-button" ng-click="createUserPrompt($event, user)">
         <md-icon>mode_edit</md-icon>
         <md-tooltip>Edit</md-tooltip>
       </md-button>
 
-      <md-button class='md-icon-button' ng-click='editCapsPrompt($event, user)'>
+      <md-button class="md-icon-button" ng-click="editCapsPrompt($event, user)">
         <md-icon>traffic</md-icon>
         <md-tooltip>Modify Capabilities</md-tooltip>
       </md-button>
 
       <!-- Right side of toolbar -->
-      <md-card-icon-actions layout-align='end center'>
-        <md-button class='md-icon-button' ng-click='deleteUser(user.username)'>
+      <md-card-icon-actions layout-align="end center">
+        <md-button class="md-icon-button" ng-click="deleteUser(user.username)">
           <md-icon>delete</md-icon>
           <md-tooltip>Destroy</md-tooltip>
         </md-button>
-        <span flex='10'>
+        <span flex="10">
         </span>
       </md-card-icon-actions>
     </md-card-actions>
@@ -80,7 +80,7 @@ users view
 
 <!-- Floating action button at the bottom right of the screen -->
 <div>
-  <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='createUserPrompt($event)'>
+  <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="createUserPrompt($event)">
     <md-icon>add</md-icon>
     <md-tooltip>Create User</md-tooltip>
   </md-button>

--- a/views/wizard/attributes.html
+++ b/views/wizard/attributes.html
@@ -1,34 +1,34 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
     <md-icon>directions_car</md-icon>
   </div>
-  <div class='wizard-content' flex>
+  <div class="wizard-content" flex>
     <h1>Select Your Deployment Specific Options</h1>
 
-    <div layout='column'>
-      <p ng-show='!wizard.base_attribs'>
+    <div layout="column">
+      <p ng-show="!wizard.base_attribs">
         No Options Available
       </p>
-      <md-input-container class='md-block' flex ng-repeat='attrib in wizard.base_attribs'>
-        <div ng-switch='attribMap[attrib].schema.type'>
-          <div ng-switch-when='str'>
+      <md-input-container class="md-block" flex ng-repeat="attrib in wizard.base_attribs">
+        <div ng-switch="attribMap[attrib].schema.type">
+          <div ng-switch-when="str">
             <label>{{attrib}}</label>
             <input type="text" ng-model="workloads.attribs[attrib]">
           </div>
-          <div ng-switch-when='int'>
+          <div ng-switch-when="int">
             <label>{{attrib}}</label>
             <input type="number" ng-model="workloads.attribs[attrib]">
           </div>
-          <div ng-switch-when='bool'>
-            <md-checkbox ng-model="workloads.attribs[attrib]" style='margin-bottom: 32px;'>
+          <div ng-switch-when="bool">
+            <md-checkbox ng-model="workloads.attribs[attrib]" style="margin-bottom: 32px;">
               {{attrib}}
             </md-checkbox>
           </div>
         </div>
       </md-input-container>
     </div>
-    <md-toolbar class='md-table-toolbar md-default' md-ink-ripple ng-if='wizard.advanced_attribs.length'>
-      <div class='md-toolbar-tools' ng-click='toggleAdvanced()'>
+    <md-toolbar class="md-table-toolbar md-default" md-ink-ripple ng-if="wizard.advanced_attribs.length">
+      <div class="md-toolbar-tools" ng-click="toggleAdvanced()">
         <span>
           <md-icon>
             developer_board
@@ -45,19 +45,19 @@
         </span>
       </div>
     </md-toolbar>
-    <div ng-slide-down='showAdvanced' duration='0.5' layout='column' style='margin-top: 16px;'>
-      <md-input-container class='md-block' flex ng-repeat='attrib in wizard.advanced_attribs'>
-        <div ng-switch='attribMap[attrib].schema.type'>
-          <div ng-switch-when='str'>
+    <div ng-slide-down="showAdvanced" duration="0.5" layout="column" style="margin-top: 16px;">
+      <md-input-container class="md-block" flex ng-repeat="attrib in wizard.advanced_attribs">
+        <div ng-switch="attribMap[attrib].schema.type">
+          <div ng-switch-when="str">
             <label>{{attrib}}</label>
             <input type="text" ng-model="workloads.attribs[attrib]">
           </div>
-          <div ng-switch-when='int'>
+          <div ng-switch-when="int">
             <label>{{attrib}}</label>
             <input type="number" ng-model="workloads.attribs[attrib]">
           </div>
-          <div ng-switch-when='bool'>
-            <md-checkbox ng-model="workloads.attribs[attrib]" style='margin-bottom: 32px;'>
+          <div ng-switch-when="bool">
+            <md-checkbox ng-model="workloads.attribs[attrib]" style="margin-bottom: 32px;">
               {{attrib}}
             </md-checkbox>
           </div>

--- a/views/wizard/deployment.html
+++ b/views/wizard/deployment.html
@@ -1,20 +1,20 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
     <md-icon>directions_run</md-icon>
   </div>
-  <div class='wizard-content' flex  layout='column'>
+  <div class="wizard-content" flex  layout="column">
     <h1>Select or Create a Deployment</h1>
-    <md-switch ng-model='workloads.createDeployment'>
+    <md-switch ng-model="workloads.createDeployment">
       Create Deployment
     </md-switch>
-    <div ng-show='workloads.createDeployment'>
-      <md-input-container class='md-block'>
+    <div ng-show="workloads.createDeployment">
+      <md-input-container class="md-block">
         <label>Deployment Name</label>
-        <input type='text' ng-model="workloads.name"/>
+        <input type="text" ng-model="workloads.name"/>
       </md-input-container>
     </div>
-    <div layout='row' ng-hide='workloads.createDeployment'>
-      <md-input-container class='md-block' style='margin-bottom: 24px;' flex>
+    <div layout="row" ng-hide="workloads.createDeployment">
+      <md-input-container class="md-block" style="margin-bottom: 24px;" flex>
         <label>Deployment</label>
         <md-select ng-model="workloads.deployment_id">
           <md-option ng-repeat="deployment in getDeployments()" value="{{deployment.id}}">
@@ -23,7 +23,7 @@
         </md-select>
       </md-input-container>
     </div>
-    <md-switch ng-model="workloads.commit" aria-label="commit" style='margin: 0;'>
+    <md-switch ng-model="workloads.commit" aria-label="commit" style="margin: 0;">
       Auto-Commit
     </md-switch>
   </div>

--- a/views/wizard/done.html
+++ b/views/wizard/done.html
@@ -1,28 +1,28 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
-    <md-icon ng-show='submitStatus == -1'>close</md-icon>
-    <md-icon ng-show='submitStatus == 0' class='rotate'>hourglass_empty</md-icon>
-    <md-icon ng-show='submitStatus == 1'>check</md-icon>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
+    <md-icon ng-show="submitStatus == -1">close</md-icon>
+    <md-icon ng-show="submitStatus == 0" class="rotate">hourglass_empty</md-icon>
+    <md-icon ng-show="submitStatus == 1">check</md-icon>
   </div>
-  <div class='wizard-content' flex>
+  <div class="wizard-content" flex>
     <h1>
       <span ng-show="submitStatus == -1">Wizard Failed</span>
       <span ng-show="submitStatus == 0">Running Wizard...</span>
       <span ng-show="submitStatus == 1">Wizard Completed!</span>
     </h1>
-    <div ng-show='submitStatus == -1' layout-align='center'>
-      <md-button class='md-primary md-raised' ng-click='steps[done-1].onStep()'>
+    <div ng-show="submitStatus == -1" layout-align="center">
+      <md-button class="md-primary md-raised" ng-click="steps[done-1].onStep()">
         Retry
       </md-button>
-      <md-button class='md-primary md-raised' ng-click='setPath("/alerts")'>
+      <md-button class="md-primary md-raised" ng-click="setPath('/alerts')">
         View Alerts
       </md-button>
     </div>
-    <div ng-show='submitStatus == 0'>
+    <div ng-show="submitStatus == 0">
       Please wait a moment!
     </div>
-    <div ng-show='submitStatus == 1'>
-      <md-button class='md-primary md-raised' ng-click='setPath("/deployments")'>
+    <div ng-show="submitStatus == 1">
+      <md-button class="md-primary md-raised" ng-click="setPath('/deployments')">
         View Deployments
       </md-button>
     </div>

--- a/views/wizard/nodes.html
+++ b/views/wizard/nodes.html
@@ -1,26 +1,26 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
     <md-icon>directions_train</md-icon>
   </div>
-  <div class='wizard-content' flex>
+  <div class="wizard-content" flex>
     <h1>Select the Services for Your Nodes</h1>
     <span ng-show="workloads.use_system">
       Installing {{ workloads.attribs['provisioner-target_os'] }} from {{ workloads.source }} deployment.
     </span>
     <md-card>
       <md-toolbar class="md-table-toolbar md-default" >
-        <div class="md-toolbar-tools" layout='row'>
+        <div class="md-toolbar-tools" layout="row">
           <h2>{{workloads.selected.length}} node{{workloads.selected.length != 1 && 's' || ''}} selected</h2>
-          <div flex style='color: #c44; font-size: 0.75em; text-align: center;'>{{steps[done].complete(true)[1]}}</div>
+          <div flex style="color: #c44; font-size: 0.75em; text-align: center;">{{steps[done].complete(true)[1]}}</div>
         </div>
         <div>
-          <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='addNodes()' ng-hide="workloads.use_system">
+          <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="addNodes()" ng-hide="workloads.use_system">
             <md-icon>add</md-icon>
             <md-tooltip>Add Nodes</md-tooltip>
           </md-button>
         </div>
         <div>
-          <md-button class='md-fab md-accent md-fab-bottom-right' ng-click='collectNodes()' ng-show="workloads.use_system">
+          <md-button class="md-fab md-accent md-fab-bottom-right" ng-click="collectNodes()" ng-show="workloads.use_system">
             <md-icon>replay</md-icon>
             <md-tooltip>Regather Nodes from Pool</md-tooltip>
           </md-button>
@@ -31,7 +31,7 @@
         <table md-table md-row-select ng-model="workloads.selected">
           <thead md-head md-order="order">
             <tr md-row>
-              <th md-column md-order-by='name'>Name</th>
+              <th md-column md-order-by="name">Name</th>
               <th md-column>Required</th>
               <th md-column>Control</th>
               <th md-column>Worker</th>
@@ -41,10 +41,10 @@
           <tbody md-body>
             <tr md-row md-select="node" md-select-id="{{node.id}}" ng-repeat="node in getNodes() | orderBy: order">
               <td md-cell>{{node.name}}</td>
-              <td md-cell ng-repeat='type in ["required","control","worker","optional"]'>
+              <td md-cell ng-repeat="type in ['required','control','worker','optional']">
                 <span flex></span>
-                <span ng-repeat='service in wizard.services' style='height: 10px;' ng-if='service.type==type'>
-                  <md-button ng-click='select(node, service)' class='md-icon-button' ng-class='{"toggled md-whiteframe-2dp": serviceMap[node.id][service.name]}'>
+                <span ng-repeat="service in wizard.services" style="height: 10px;" ng-if="service.type==type">
+                  <md-button ng-click="select(node, service)" class="md-icon-button" ng-class="{'toggled md-whiteframe-2dp': serviceMap[node.id][service.name]}">
                     <md-icon>
                       {{service.icon || "blur_circular"}}
                     </md-icon>

--- a/views/wizard/os.html
+++ b/views/wizard/os.html
@@ -1,14 +1,14 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
     <md-icon>directions_bike</md-icon>
   </div>
-  <div class='wizard-content' flex layout='column'>
+  <div class="wizard-content" flex layout="column">
     <h1>Select Metal OS or Provider</h1>
     <div>
-      <md-switch ng-model='workloads.use_system' ng-if='wizard.system_nodes' ng-disabled="workloads.use_system ? onTrue : onFalse">
+      <md-switch ng-model="workloads.use_system" ng-if="wizard.system_nodes" ng-disabled="workloads.use_system ? onTrue : onFalse">
         Use Existing Nodes?
       </md-switch>
-      <div ng-if='wizard.system_nodes && workloads.use_system'>
+      <div ng-if="wizard.system_nodes && workloads.use_system">
         <md-icon title="Deployment">dashboard</md-icon>
         <md-input-container flex>
           <label>Pool</label>
@@ -28,12 +28,12 @@
           </md-select>
         </md-input-container>
       </div>
-      <div ng-if='wizard.create_nodes && !workloads.use_system'>
+      <div ng-if="wizard.create_nodes && !workloads.use_system">
         <md-icon>cloud</md-icon>
         <md-input-container flex>
           <label>Cloud Provider</label>
           <md-select aria-label="provider select" ng-model="workloads.provider" ng-change="createNodes()" >
-            <md-option ng-repeat="provider in _providers" value="{{provider.name}}" ng-if='provider.type != "MetalProvider" && provider.type != ""'>
+            <md-option ng-repeat="provider in _providers" value="{{provider.name}}" ng-if="provider.type != 'MetalProvider' && provider.type != ''">
               {{provider.name}}
             </md-option>
           </md-select>
@@ -42,11 +42,11 @@
     </div>
 
     <h1>Add Public SSH Key (optional)</h1>
-      <span id="$index" ng-repeat='key in workloads.keys'>
-        <md-input-container class='md-block'>
+      <span id="$index" ng-repeat="key in workloads.keys">
+        <md-input-container class="md-block">
           <input type="text" aria-label="keys name" placeholder="Key Name" width="10" ng-model="workloads.keys[$index][0]">
         </md-input-container>
-        <md-input-container class='md-block'>
+        <md-input-container class="md-block">
           <input type="textarea" placeholder="Key Value" aria-label="key value" ng-model="workloads.keys[$index][1]">
         </md-input-container>
       </span>

--- a/views/wizard/overview.html
+++ b/views/wizard/overview.html
@@ -1,13 +1,13 @@
-<div layout='column' layout-gt-xs='row' class='wizard-pane'>
-  <div class='wizard-icon'>
+<div layout="column" layout-gt-xs="row" class="wizard-pane">
+  <div class="wizard-icon">
     <md-icon>airplanemode_active</md-icon>
   </div>
-  <div class='wizard-content' flex>
+  <div class="wizard-content" flex>
     <h1>Overview the JSON That Will Be Sent</h1>
-    <div layout='row'>
+    <div layout="row">
       <pre flex>{{generateBlob() | json}}</pre>
-      <div layout-padding layout-align='center' layou='column'>
-        <md-button class='md-primary md-icon-button' ng-click='editInHelper()'>
+      <div layout-padding layout-align="center" layou="column">
+        <md-button class="md-primary md-icon-button" ng-click="editInHelper()">
           <md-icon>create</md-icon>
           <md-tooltip>Edit in API Call Helper</md-tooltip>
         </md-button>

--- a/views/workloads.html
+++ b/views/workloads.html
@@ -1,6 +1,6 @@
 <md-card>
-  <md-toolbar class='md-table-toolbar md-default'>
-    <div class='md-toolbar-tools' layout='row'>
+  <md-toolbar class="md-table-toolbar md-default">
+    <div class="md-toolbar-tools" layout="row">
       <md-icon>
         {{wizard.icon || 'create_new_folder'}}
       </md-icon>
@@ -11,21 +11,21 @@
     </div>
   </md-toolbar>
 
-  <md-content layout-padding layout='column'>
-    <div layout='row'>
-      <div ng-repeat='step in steps' class='step' ng-class="{completed:$index < done, progress: $index==done}" ng-if='!step.finalStep' ng-click='setProgress($index)'>
+  <md-content layout-padding layout="column">
+    <div layout="row">
+      <div ng-repeat="step in steps" class="step" ng-class="{completed:$index < done, progress: $index==done}" ng-if="!step.finalStep" ng-click="setProgress($index)">
         <md-icon>{{done > $index ? 'done' : step.icon}}</md-icon>
         <md-tooltip>
           {{step.name}}
         </md-tooltip>
       </div>
     </div>
-    <ng-include src='steps[done].path' class='wizard-include' onload='setCanNext()'> </ng-include>
-    <md-card-actions layout='row' layout-align='end center' ng-hide='steps[done].finalStep'>
-      <md-button class='md-primary' ng-disabled='done == 0' ng-click='prevStep()'>
+    <ng-include src="steps[done].path" class="wizard-include" onload="setCanNext()"> </ng-include>
+    <md-card-actions layout="row" layout-align="end center" ng-hide="steps[done].finalStep">
+      <md-button class="md-primary" ng-disabled="done == 0" ng-click="prevStep()">
         Back
       </md-button>
-      <md-button class='md-primary md-raised' ng-disabled='!steps[done].complete() || !canNext' ng-click='nextStep()'>
+      <md-button class="md-primary md-raised" ng-disabled="!steps[done].complete() || !canNext" ng-click="nextStep()">
         Next
       </md-button>
     </md-card-actions>


### PR DESCRIPTION
### HTML

- Changed many tags attributes from single quotes (`onclick='hello()'`) to double quotes (`onclick="thisIsCorrect()"`)
- Fixed numerous unclosed or dangling closing `div`, `md-card`, `a`, and `td` tags
- Fixed little indentation

### CSS

- Added prefixes
- Fixed a few syntax errors (`whitespace` to `white-space`)
