### PR TITLE
fix link for node_role attribs so that it does details via API helper

### DIFF
--- a/js/node_roles.js
+++ b/js/node_roles.js
@@ -2,7 +2,7 @@
 node role controller
 */
 (function () {
-  angular.module('app').controller('NodeRolesCtrl', function ($scope, $location, debounce, $routeParams, $mdMedia, $mdDialog, $timeout, api) {
+  angular.module('app').controller('NodeRolesCtrl', function ($scope, $location, debounce, $routeParams, $mdMedia, $mdDialog, $timeout, localStorageService, api) {
 
     $scope.$emit('title', 'Node Roles'); // shows up on the top toolbar
 
@@ -37,6 +37,12 @@ node role controller
     $scope.$watchCollection('scroll', $scope.updateScroll)
 
     this.selected = [];
+
+    $scope.editAttribInHelper = function (id) {
+      localStorageService.add('api_helper_method', 'get');
+      localStorageService.add('api_helper_route', '/api/v2/attribs/' + id);
+      $location.path("/api_helper");
+    };
 
     // converts the _node_roles object that rootScope has into an array
     $scope.getNodeRoles = function () {

--- a/views/attrib_render.tmpl.html
+++ b/views/attrib_render.tmpl.html
@@ -11,8 +11,8 @@
     <table layout-padding flex>
       <tbody>
         <tr ng-repeat="attrib in attribs | orderBy:'name'">
-          <td class="label" valign="top">
-            <a ng-click="alert(attrib.id)" title="{{attrib.description}}">
+          <td class="label" valign="top" >
+            <a ng-click="editAttribInHelper(attrib.id)" title="{{attrib.description}}">
               {{attrib.name}}
             </a>
           </td>


### PR DESCRIPTION
link was broken.
this makes it easier to work with attributes that are [object] instead of showing values,