### PR TITLE
Allow users to edit leases for network ranges

### DIFF
--- a/js/networks.js
+++ b/js/networks.js
@@ -157,7 +157,7 @@ network controller
         var original = $scope._ranges[id];
         if (JSON.stringify(range) === JSON.stringify(original))
           return;
-
+        console.log(range);
         api("/api/v2/network_ranges/" + id, {
           method: "PUT",
           data: range

--- a/js/networks.js
+++ b/js/networks.js
@@ -157,8 +157,7 @@ network controller
         var original = $scope._ranges[id];
         if (JSON.stringify(range) === JSON.stringify(original))
           return;
-        console.log(range);
-        api("/api/v2/network_ranges/" + id, {
+        api("/api/v2/network_ranges/" + range.id, {
           method: "PUT",
           data: range
         }).

--- a/views/networks_singular.html
+++ b/views/networks_singular.html
@@ -269,18 +269,20 @@
               </td>
               <td>
                 <input ng-show='range.allow_anon_leases' type="number" class="table-input" ng-readonly="!editingRanges" ng-model="range.anon_lease_time" />
+                <span ng-show='range.name=="dhcp" && !range.allow_anon_leases'>tip: set Anon Lease</span>
               </td>
               <td>
                 <input type="checkbox" ng-readonly="!editingRanges" ng-model="range.allow_bound_leases" />
               </td>
               <td>
                 <input ng-show='range.allow_bound_leases' type="number" class="table-input" ng-readonly="!editingRanges" ng-model="range.bound_lease_time" />
+                <span ng-show='range.name=="host" && !range.allow_bound_leases'>tip: set Bound Lease</span>
               </td>
               <td>
                 <md-button class="md-icon-button" ng-click="deleteRange(range.id)">
                   <md-icon>delete</md-icon>
                   <md-tooltip>Delete Range</md-tooltip>
-                </md-button>
+                </md-button>                
               </td>
             </tr>
           </tbody>

--- a/views/networks_singular.html
+++ b/views/networks_singular.html
@@ -185,6 +185,7 @@
         </td>
       </tr>
     </table>
+  Questions? See the <a href="http://digital-rebar.readthedocs.io/en/latest/deployment/networks/README.html">Networking Specific Help</a>.
   </md-card-content>
 </md-card>
 
@@ -248,6 +249,9 @@
             <th>Name</th>
             <th>First IP</th>
             <th>Last IP</th>
+            <th colspan="2">Anon Lease</th>
+            <th colspan="2">Bound Lease</th>
+            <th></th>
           </thead>
           <tbody>
             <tr ng-repeat="(id, range) in ranges">
@@ -259,6 +263,18 @@
               </td>
               <td>
                 <input type="text" class="table-input" ng-readonly="!editingRanges" ng-model="range.last" />
+              </td>
+              <td>
+                <input type="checkbox" ng-readonly="!editingRanges" ng-model="range.allow_anon_leases" />
+              </td>
+              <td>
+                <input ng-show='range.allow_anon_leases' type="number" class="table-input" ng-readonly="!editingRanges" ng-model="range.anon_lease_time" />
+              </td>
+              <td>
+                <input type="checkbox" ng-readonly="!editingRanges" ng-model="range.allow_bound_leases" />
+              </td>
+              <td>
+                <input ng-show='range.allow_bound_leases' type="number" class="table-input" ng-readonly="!editingRanges" ng-model="range.bound_lease_time" />
               </td>
               <td>
                 <md-button class="md-icon-button" ng-click="deleteRange(range.id)">


### PR DESCRIPTION
As per @galthaus discussion, the default is false, false; however, new host or dhcp ranges will be fixed by the API when created.

I review the @Meshiest version of this patch and it is very similar.

NOTE: It requires the bug #184 to be fixed in core because the API does not currently allow updates to these fields.