### PR TITLE
remove requirement that deployments are proposed

### DIFF
--- a/js/workloads.js
+++ b/js/workloads.js
@@ -37,10 +37,6 @@ workloads controller
             // no deployment selected
             if (!deployment)
               return false;
-
-            // deployment isn't proposed
-            if (deployment.state != 0)
-              return false;            
           }
           // set use system based on wizard
           workloads.use_system = !wizard.create_nodes;


### PR DESCRIPTION
this check was preventing deployments from being selected for non-obvious reasons.  

it's not really required that deployments be proposed.