### PR TITLE
BUG services should link to the node_role

### DIFF
--- a/app/assets/views/deployments.html
+++ b/app/assets/views/deployments.html
@@ -56,7 +56,7 @@ deployments view
           <md-icon>close</md-icon>
         </span>
         <span ng-hide="matrix[id].loading" ng-repeat="service in matrix[id].services">
-          <md-button class="md-primary md-raised square-button" md-theme="status_{{states[service.state]}}" ng-href="#!/deployment_roles/{{service.id}}" style="margin: 6px 3px 3px 0;">
+          <md-button class="md-primary md-raised square-button" md-theme="status_{{states[service.state]}}" ng-href="#!/node_roles/{{service.id}}" style="margin: 6px 3px 3px 0;">
             <md-tooltip md-direction="bottom">
               {{service.name}}
             </md-tooltip>


### PR DESCRIPTION
When refactoring to use the optimized view, the wrong link target was chosen.

This corrects that change.

Fixes bug #415 